### PR TITLE
Select single-region-fleet senario by default; Deprioritize UI order of custom scenario

### DIFF
--- a/GameLift-Unity/Assets/Editor/Custom Scenario/Deployer.cs
+++ b/GameLift-Unity/Assets/Editor/Custom Scenario/Deployer.cs
@@ -15,13 +15,15 @@ namespace AmazonGameLift.Custom
         public override string DisplayName => "Custom Scenario";
 
         public override string Description =>
-            "This deployment scenario is a custom one";
+            "This is a custom deployment scenario for you to edit!";
 
         public override string HelpUrl => "";
 
         public override string ScenarioFolder => "Assets/Editor/Custom Scenario";
 
         public override bool HasGameServer => false;
+
+        public override int PreferredUiOrder => 99;
 
         protected override Task<DeploymentResponse> Deploy(DeploymentRequest request)
         {

--- a/GameLift-Unity/Assets/com.amazonaws.gamelift/Editor/Deployment/DeploymentSettings.cs
+++ b/GameLift-Unity/Assets/com.amazonaws.gamelift/Editor/Deployment/DeploymentSettings.cs
@@ -219,7 +219,7 @@ namespace AmazonGameLift.Editor
 
         public void Restore()
         {
-            ScenarioIndex = 0;
+            ScenarioIndex = 1; // Selects "Single-Region Fleet" Deployment Scenario by default
             BuildFilePath = null;
             BuildFolderPath = null;
             GetSettingResponse response = _coreApi.GetSetting(SettingsKeys.DeploymentGameName);

--- a/GameLift-Unity/Assets/com.amazonaws.gamelift/Editor/Deployment/DeploymentWindow.cs
+++ b/GameLift-Unity/Assets/com.amazonaws.gamelift/Editor/Deployment/DeploymentWindow.cs
@@ -87,12 +87,12 @@ namespace AmazonGameLift.Editor
 
             titleContent = new GUIContent(_textProvider.Get(Strings.TitleDeployment));
             _model = DeploymentSettingsFactory.Create();
-            string label = _textProvider.Get(Strings.LabelDeploymentHelp);
-            _deploymentHelpLinkButton = new HyperLinkButton(label, Urls.AwsHelpDeployment, ResourceUtility.GetHyperLinkStyle());
+            string deploymentHelpLabelText = _textProvider.Get(Strings.LabelDeploymentHelp);
+            _deploymentHelpLinkButton = new HyperLinkButton(deploymentHelpLabelText, Urls.AwsHelpDeployment, ResourceUtility.GetHyperLinkStyle());
             _scenarioHelpLinkButton = new HyperLinkButton(_labelScenarioHelp, string.Empty, ResourceUtility.GetHyperLinkStyle());
             _statusLabel = new StatusLabel();
-            string labelCfnConsole = _textProvider.Get(Strings.LabelDeploymentCloudFormationConsole);
-            _cfnConsoleLinkButton = new HyperLinkButton(labelCfnConsole, Urls.AwsCloudFormationConsole, ResourceUtility.GetHyperLinkStyle());
+            string goToCloudFormationConsoleLabelText = _textProvider.Get(Strings.LabelDeploymentCloudFormationConsole);
+            _cfnConsoleLinkButton = new HyperLinkButton(goToCloudFormationConsoleLabelText, Urls.AwsCloudFormationConsole, ResourceUtility.GetHyperLinkStyle());
             SetWindowSize(WindowIdleHeightNoFormPixels);
             _model.Refresh();
             _model.Restore();


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Change the default deployment scenario to "Single-Region Fleet"
* Order custom scenario lower in the UI

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
