### PR TITLE
Add CreatedBy fleet tag to cloud formation templates

### DIFF
--- a/GameLift-Unity/Assets/com.amazonaws.gamelift/Editor/Resources/CloudFormation/scenario2_single_fleet/cloudformation.yml
+++ b/GameLift-Unity/Assets/com.amazonaws.gamelift/Editor/Resources/CloudFormation/scenario2_single_fleet/cloudformation.yml
@@ -348,6 +348,9 @@ Resources:
           - ConcurrentExecutions: 1
             LaunchPath: !Ref LaunchPathParameter
             Parameters: !Ref LaunchParametersParameter
+      Tags:
+        - Key: "CreatedBy"
+          Value: "AmazonGameLiftUnityPlugin"
 
   AliasResource:
     Type: "AWS::GameLift::Alias"

--- a/GameLift-Unity/Assets/com.amazonaws.gamelift/Editor/Resources/CloudFormation/scenario3_mrf_queue/cloudformation.yml
+++ b/GameLift-Unity/Assets/com.amazonaws.gamelift/Editor/Resources/CloudFormation/scenario3_mrf_queue/cloudformation.yml
@@ -572,6 +572,9 @@ Resources:
           - ConcurrentExecutions: 1
             LaunchPath: !Ref LaunchPathParameter
             Parameters: !Ref LaunchParametersParameter
+      Tags:
+        - Key: "CreatedBy"
+          Value: "AmazonGameLiftUnityPlugin"
 
   SimpleMatchmakerLambdaFunction:
     Type: "AWS::Lambda::Function"

--- a/GameLift-Unity/Assets/com.amazonaws.gamelift/Editor/Resources/CloudFormation/scenario4_spot_fleets/cloudformation.yml
+++ b/GameLift-Unity/Assets/com.amazonaws.gamelift/Editor/Resources/CloudFormation/scenario4_spot_fleets/cloudformation.yml
@@ -573,6 +573,9 @@ Resources:
           - ConcurrentExecutions: 1
             LaunchPath: !Ref LaunchPathParameter
             Parameters: !Ref LaunchParametersParameter
+      Tags:
+        - Key: "CreatedBy"
+          Value: "AmazonGameLiftUnityPlugin"
 
   C5LargeSpotFleetResource:
     Type: "AWS::GameLift::Fleet"
@@ -609,6 +612,9 @@ Resources:
           - ConcurrentExecutions: 1
             LaunchPath: !Ref LaunchPathParameter
             Parameters: !Ref LaunchParametersParameter
+      Tags:
+        - Key: "CreatedBy"
+          Value: "AmazonGameLiftUnityPlugin"
 
   OnDemandFleetResource:
     Type: "AWS::GameLift::Fleet"
@@ -645,6 +651,9 @@ Resources:
           - ConcurrentExecutions: 1
             LaunchPath: !Ref LaunchPathParameter
             Parameters: !Ref LaunchParametersParameter
+      Tags:
+        - Key: "CreatedBy"
+          Value: "AmazonGameLiftUnityPlugin"
 
   SimpleMatchmakerLambdaFunction:
     Type: "AWS::Lambda::Function"

--- a/GameLift-Unity/Assets/com.amazonaws.gamelift/Editor/Resources/CloudFormation/scenario5_flexmatch/cloudformation.yml
+++ b/GameLift-Unity/Assets/com.amazonaws.gamelift/Editor/Resources/CloudFormation/scenario5_flexmatch/cloudformation.yml
@@ -597,6 +597,9 @@ Resources:
           - ConcurrentExecutions: 1
             LaunchPath: !Ref LaunchPathParameter
             Parameters: !Ref LaunchParametersParameter
+      Tags:
+        - Key: "CreatedBy"
+          Value: "AmazonGameLiftUnityPlugin"
 
   C5LargeSpotFleetResource:
     Type: "AWS::GameLift::Fleet"
@@ -633,6 +636,9 @@ Resources:
           - ConcurrentExecutions: 1
             LaunchPath: !Ref LaunchPathParameter
             Parameters: !Ref LaunchParametersParameter
+      Tags:
+        - Key: "CreatedBy"
+          Value: "AmazonGameLiftUnityPlugin"
 
   OnDemandFleetResource:
     Type: "AWS::GameLift::Fleet"
@@ -669,6 +675,9 @@ Resources:
           - ConcurrentExecutions: 1
             LaunchPath: !Ref LaunchPathParameter
             Parameters: !Ref LaunchParametersParameter
+      Tags:
+        - Key: "CreatedBy"
+          Value: "AmazonGameLiftUnityPlugin"
 
   MatchmakingConfiguration:
     Type: "AWS::GameLift::MatchmakingConfiguration"


### PR DESCRIPTION
*Issue #, if available:* GLIFT-15324 (no issue #)

*Description of changes:*
- Adding CreatedBy: AmazonGameLiftUnityPlugin tag to our fleet resources in the cloud formation templates.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
