### PR TITLE
Revert "Add CreatedBy fleet tag to cloud formation templates"

### DIFF
--- a/GameLift-Unity/Assets/com.amazonaws.gamelift/Editor/Resources/CloudFormation/scenario2_single_fleet/cloudformation.yml
+++ b/GameLift-Unity/Assets/com.amazonaws.gamelift/Editor/Resources/CloudFormation/scenario2_single_fleet/cloudformation.yml
@@ -348,9 +348,6 @@ Resources:
           - ConcurrentExecutions: 1
             LaunchPath: !Ref LaunchPathParameter
             Parameters: !Ref LaunchParametersParameter
-      Tags:
-        - Key: "CreatedBy"
-          Value: "AmazonGameLiftUnityPlugin"
 
   AliasResource:
     Type: "AWS::GameLift::Alias"

--- a/GameLift-Unity/Assets/com.amazonaws.gamelift/Editor/Resources/CloudFormation/scenario3_mrf_queue/cloudformation.yml
+++ b/GameLift-Unity/Assets/com.amazonaws.gamelift/Editor/Resources/CloudFormation/scenario3_mrf_queue/cloudformation.yml
@@ -572,9 +572,6 @@ Resources:
           - ConcurrentExecutions: 1
             LaunchPath: !Ref LaunchPathParameter
             Parameters: !Ref LaunchParametersParameter
-      Tags:
-        - Key: "CreatedBy"
-          Value: "AmazonGameLiftUnityPlugin"
 
   SimpleMatchmakerLambdaFunction:
     Type: "AWS::Lambda::Function"

--- a/GameLift-Unity/Assets/com.amazonaws.gamelift/Editor/Resources/CloudFormation/scenario4_spot_fleets/cloudformation.yml
+++ b/GameLift-Unity/Assets/com.amazonaws.gamelift/Editor/Resources/CloudFormation/scenario4_spot_fleets/cloudformation.yml
@@ -573,9 +573,6 @@ Resources:
           - ConcurrentExecutions: 1
             LaunchPath: !Ref LaunchPathParameter
             Parameters: !Ref LaunchParametersParameter
-      Tags:
-        - Key: "CreatedBy"
-          Value: "AmazonGameLiftUnityPlugin"
 
   C5LargeSpotFleetResource:
     Type: "AWS::GameLift::Fleet"
@@ -612,9 +609,6 @@ Resources:
           - ConcurrentExecutions: 1
             LaunchPath: !Ref LaunchPathParameter
             Parameters: !Ref LaunchParametersParameter
-      Tags:
-        - Key: "CreatedBy"
-          Value: "AmazonGameLiftUnityPlugin"
 
   OnDemandFleetResource:
     Type: "AWS::GameLift::Fleet"
@@ -651,9 +645,6 @@ Resources:
           - ConcurrentExecutions: 1
             LaunchPath: !Ref LaunchPathParameter
             Parameters: !Ref LaunchParametersParameter
-      Tags:
-        - Key: "CreatedBy"
-          Value: "AmazonGameLiftUnityPlugin"
 
   SimpleMatchmakerLambdaFunction:
     Type: "AWS::Lambda::Function"

--- a/GameLift-Unity/Assets/com.amazonaws.gamelift/Editor/Resources/CloudFormation/scenario5_flexmatch/cloudformation.yml
+++ b/GameLift-Unity/Assets/com.amazonaws.gamelift/Editor/Resources/CloudFormation/scenario5_flexmatch/cloudformation.yml
@@ -597,9 +597,6 @@ Resources:
           - ConcurrentExecutions: 1
             LaunchPath: !Ref LaunchPathParameter
             Parameters: !Ref LaunchParametersParameter
-      Tags:
-        - Key: "CreatedBy"
-          Value: "AmazonGameLiftUnityPlugin"
 
   C5LargeSpotFleetResource:
     Type: "AWS::GameLift::Fleet"
@@ -636,9 +633,6 @@ Resources:
           - ConcurrentExecutions: 1
             LaunchPath: !Ref LaunchPathParameter
             Parameters: !Ref LaunchParametersParameter
-      Tags:
-        - Key: "CreatedBy"
-          Value: "AmazonGameLiftUnityPlugin"
 
   OnDemandFleetResource:
     Type: "AWS::GameLift::Fleet"
@@ -675,9 +669,6 @@ Resources:
           - ConcurrentExecutions: 1
             LaunchPath: !Ref LaunchPathParameter
             Parameters: !Ref LaunchParametersParameter
-      Tags:
-        - Key: "CreatedBy"
-          Value: "AmazonGameLiftUnityPlugin"
 
   MatchmakingConfiguration:
     Type: "AWS::GameLift::MatchmakingConfiguration"


### PR DESCRIPTION
Reverts aws/amazon-gamelift-plugin-unity#15

Tags are not yet supported for Fleet Resources in Cloud Formation.