### PR TITLE
Merge release 1.1.1 changes into main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,49 +1,68 @@
 CHANGELOG
 
+# 1.1.1 (10/13/2021)
+
+- Deployment Scenario
+    - Add support to create player session in "Single Region Fleet" deployment scenario
+    - Pass back player session ID in all get_game_connection responses
+- Sample Game
+    - Sample game client now accepts player session ID from get_game_connection responses and pass it to the game server
+      after establishing a connection
+    - Sample game server now accepts player session ID from client and call AcceptPlayerSession with the provided ID.
+      This fixes deployment scenarios not accounting for fulfilled player session slots
+- Testing
+    - Added assembly definition to run plugin unit tests via the Unity test runner
+    - Fixed some unit tests
+
 # 1.1.0 (09/28/2021)
+
 - Files
-	- Update project file structure to comply with [Unity standards](https://docs.unity3d.com/Manual/CustomPackages.html)
-		- Move package.json into project root; remove unnecessary Unity project wrapper
-		- Move Core Library under `Runtime`; change .csproj to use the vs2019 convention and updated to use dotnet build tool to resolve dependencies
-		- Move sample game project to `Sample~`
-		- Move scripts to `Scripts~`; modularize scripts and add more fail-fast mechanisms
-		- Use npm to package the plugin tarball
-		- Remove other misc files
-	- Update assembly definition namings to comply with [Unity convention](https://docs.unity3d.com/Manual/cus-tests.html)
+    - Update project file structure to comply
+      with [Unity standards](https://docs.unity3d.com/Manual/CustomPackages.html)
+        - Move package.json into project root; remove unnecessary Unity project wrapper
+        - Move Core Library under `Runtime`; change .csproj to use the vs2019 convention and updated to use dotnet build
+          tool to resolve dependencies
+        - Move sample game project to `Sample~`
+        - Move scripts to `Scripts~`; modularize scripts and add more fail-fast mechanisms
+        - Use npm to package the plugin tarball
+        - Remove other misc files
+    - Update assembly definition namings to comply
+      with [Unity convention](https://docs.unity3d.com/Manual/cus-tests.html)
 - Documentation
-	- Update and re-format READMEs
-	- Use the correct URL for deployment scenario help link
+    - Update and re-format READMEs
+    - Use the correct URL for deployment scenario help link
 - Bug Fix
-	- Fix bug where bootstrap S3 buckets show all buckets in all regions, add async loading for S3 bucket loading
+    - Fix bug where bootstrap S3 buckets show all buckets in all regions, add async loading for S3 bucket loading
 
 # 1.0.0 (09/17/2021)
 
 - Documentation
-	- Update root and sample game READMEs
-	- Delete plugin README in favor of AWS documentation links in the plug-in UI
-	- Update Download GameLiftLocal and JDK instructions in settings UI
+    - Update root and sample game READMEs
+    - Delete plugin README in favor of AWS documentation links in the plug-in UI
+    - Update Download GameLiftLocal and JDK instructions in settings UI
 - Bug Fix
-	- Fix "NotConfigured" font style in settings UI
+    - Fix "NotConfigured" font style in settings UI
 
 # 0.2.5 (09/16/2021)
 
 - Security
-	- Add server-side encryption, versioning and audit-logging during bootstrap bucket creation
-	- Add WAF/WebACL to all CloudFormation templates
+    - Add server-side encryption, versioning and audit-logging during bootstrap bucket creation
+    - Add WAF/WebACL to all CloudFormation templates
 - Testing
-	- Add integ/load tests for CloudFormation templates
+    - Add integ/load tests for CloudFormation templates
 - Documentation
-	- Update help links to the latest 'unity-plug-in.html' URLs
-	- Add README for CloudFormation template development
-	- Update fleet descriptions in CloudFormation templates
+    - Update help links to the latest 'unity-plug-in.html' URLs
+    - Add README for CloudFormation template development
+    - Update fleet descriptions in CloudFormation templates
 - Bug Fix
-	- Remove fleet tags in CloudFormation templates
-	- Fix local testing NextStep label not showing
-	- Increase height for several UI windows to compensate for the recent font size and margin changes
-	- Require setup steps to be run from root directory; Add more descriptive logs to the setup scripts
-	- Rename several occurrences of "GameLift Unity Plugin" to "GameLift Plugin for Unity"
+    - Remove fleet tags in CloudFormation templates
+    - Fix local testing NextStep label not showing
+    - Increase height for several UI windows to compensate for the recent font size and margin changes
+    - Require setup steps to be run from root directory; Add more descriptive logs to the setup scripts
+    - Rename several occurrences of "GameLift Unity Plugin" to "GameLift Plugin for Unity"
 
 # 0.2.4 (09/15/2021)
+
 - Bump up GameLiftLocal readiness delay to 10 seconds
 - Add "CreatedBy" Tag for plugin-created fleets
 - Move powershell scripts to bin/windows
@@ -67,7 +86,7 @@ CHANGELOG
 - Add AWS Logo and retexture toolbar to use the default Unity toolbar styling
 - Enable Local Testing UI regardless if Java is configured (Temp fix to issue #9)
 - Reorder and rename sample game menu items
-- Select "Single-Region Fleet" deployment scenario by default 
+- Select "Single-Region Fleet" deployment scenario by default
 - Removed PDF documentation and related button. Users should go to AWS docs for source of truth
 - Removed redundant files related to deployment scenarios
 - Ensured all files have license file headers
@@ -83,61 +102,63 @@ CHANGELOG
 - Revamped Settings UI
 - Added a "Local Mode" and "GameLift Mode" to enable user to easily select the localhost endpoint
 - Hint users that they are in "Local Mode" when running against server on https://localhost
-- Made the default bucket policy to be "None", and added warning regarding potential fleet creation 
-failure if user selects other bucket policy options, e.g. 3 days or 7 days
+- Made the default bucket policy to be "None", and added warning regarding potential fleet creation failure if user
+  selects other bucket policy options, e.g. 3 days or 7 days
 - Allow user to customize S3 bucket name during bootstrap bucket creation
 - Other minor bug fixes and usability/string changes
 
 # 0.1.0 (08/09/2021)
+
 ## Added:
+
 - Plugin installation package and the plugin file structure
 - The GameLift item in the Unity menu bar with the following sub-menu items:
-	- Plugin Settings
-	- Local Testing
-	- Deployment
+    - Plugin Settings
+    - Local Testing
+    - Deployment
 - The GameLift Plugin Settings window with the following configurations:
-	- .NET
-		- Ability to update the .NET version
-	- JRE
-		- Ability to download JRE
-	- Local Testing
-		- Ability to download GameLift Local
-		- Ability to specify the path to the GameLiftLocal.jar file
-	- AWS profile
-		- Ability to add a new profile
-		- Ability to choose an existing profile
-		- Ability to specify a region
-		- Ability to open the AWS instructions
-	- AWS account bootstrapping
-		- Ability to create a new S3 bucket
-			- Ability to specify an expiration date of the S3 bucket
-		- Ability to choose an existing S3 bucket
-			- Ability to search by the S3 bucket name
-		- Displaying the currently selected S3 bucket
-		- Ability to open the S3 console
-	- Displaying "Configured" and "Not Configured" statuses of the plugin settings
-	- Automatically displaying the GameLift Plugin Settings window when the plugin is not fully configured
+    - .NET
+        - Ability to update the .NET version
+    - JRE
+        - Ability to download JRE
+    - Local Testing
+        - Ability to download GameLift Local
+        - Ability to specify the path to the GameLiftLocal.jar file
+    - AWS profile
+        - Ability to add a new profile
+        - Ability to choose an existing profile
+        - Ability to specify a region
+        - Ability to open the AWS instructions
+    - AWS account bootstrapping
+        - Ability to create a new S3 bucket
+            - Ability to specify an expiration date of the S3 bucket
+        - Ability to choose an existing S3 bucket
+            - Ability to search by the S3 bucket name
+        - Displaying the currently selected S3 bucket
+        - Ability to open the S3 console
+    - Displaying "Configured" and "Not Configured" statuses of the plugin settings
+    - Automatically displaying the GameLift Plugin Settings window when the plugin is not fully configured
 - The Local Testing window providing the following functionality:
-	- Ability to specify the build path
-	- Ability to specify the GL Local port
+    - Ability to specify the build path
+    - Ability to specify the GL Local port
 - 5 predefined deployment scenario templates:
-	- Auth Only
-	- Single-Region Fleet
-	- Multi-Region Fleets with Queue and Custom Matchmaker
-	- SPOT Fleets with Queue and Custom Matchmaker
-	- FlexMatch
+    - Auth Only
+    - Single-Region Fleet
+    - Multi-Region Fleets with Queue and Custom Matchmaker
+    - SPOT Fleets with Queue and Custom Matchmaker
+    - FlexMatch
 - The Deployment window providing the following functionality:
-	- Ability to choose a predefined scenario for deployment
-		- Displaying the scenario template description
-		- Ability to open the AWS instructions
-	- Ability to choose a custom scenario for deployment
-	- Ability to specify a game name
-	- Ability to specify a build path
-	- Ability to start deployment
-	- Ability to cancel current deployment
-	- Displaying the stack deployment status and details
-	- Displaying the deployment outcomes (Cognito Client ID, API Gateway Endpoint)
-	- Ability to open the AWS CloudFormation console
+    - Ability to choose a predefined scenario for deployment
+        - Displaying the scenario template description
+        - Ability to open the AWS instructions
+    - Ability to choose a custom scenario for deployment
+    - Ability to specify a game name
+    - Ability to specify a build path
+    - Ability to start deployment
+    - Ability to cancel current deployment
+    - Displaying the stack deployment status and details
+    - Displaying the deployment outcomes (Cognito Client ID, API Gateway Endpoint)
+    - Ability to open the AWS CloudFormation console
 - A game sample for testing the plugin
 - A custom scenario sample
 - Dark/light Unity theme support

--- a/Editor/Resources/CloudFormation/scenario2_single_fleet/tests/test.py
+++ b/Editor/Resources/CloudFormation/scenario2_single_fleet/tests/test.py
@@ -95,9 +95,10 @@ def main():
         print(f"Received game connection info: {game_connection_info}")
         assert game_connection_info['IpAddress'] != ''
         assert game_connection_info['Port'] > 0
-        # TODO: GameLift currently does not support DnsName in SearchGameSessions result. This will be fixed soon.
-        #assert "us-west-2" in game_connection_info['DnsName'], \
-        #    f"Expect {game_connection_info['DnsName']} to contain 'us-west-2'"
+        assert "us-west-2" in game_connection_info['DnsName'], \
+            f"Expect {game_connection_info['DnsName']} to contain 'us-west-2'"
+        assert "psess-" in game_connection_info['PlayerSessionId'], \
+            f"Expect {game_connection_info['PlayerSessionId']} to contain 'psess-'"
         assert "us-west-2" in game_connection_info['GameSessionArn'], \
             f"Expect {game_connection_info['GameSessionArn']} to contain 'us-west-2'"
         print("Verified game connection info:", game_connection_info)

--- a/Editor/Resources/CloudFormation/scenario3_mrf_queue/lambda/game_session_event_handler.py
+++ b/Editor/Resources/CloudFormation/scenario3_mrf_queue/lambda/game_session_event_handler.py
@@ -27,6 +27,7 @@ def handler(event, context):
     dns_name = message['detail'].get('dnsName')
     port = message['detail'].get('port')
     game_session_arn = message['detail'].get('gameSessionArn')
+    player_sessions = message['detail'].get('placedPlayerSessions')
 
     game_session_placement_table_name = os.environ['GameSessionPlacementTableName']
 
@@ -41,6 +42,7 @@ def handler(event, context):
             'DnsName': dns_name,
             'Port': port,
             'GameSessionArn': game_session_arn,
-            'ExpirationTime': start_time + DEFAULT_TTL_IN_SECONDS
+            'ExpirationTime': start_time + DEFAULT_TTL_IN_SECONDS,
+            'PlayerSessions': player_sessions
         }
     )

--- a/Editor/Resources/CloudFormation/scenario3_mrf_queue/tests/test.py
+++ b/Editor/Resources/CloudFormation/scenario3_mrf_queue/tests/test.py
@@ -65,14 +65,6 @@ def main():
                     Username=regional_username,
                     Password=PASSWORD,
                 )
-                # TODO: TEMP
-                # cognito_idp.admin_create_user(
-                #     UserPoolId=user_pool_id,
-                #     Username=regional_username,
-                #     TemporaryPassword=PASSWORD,
-                #     DesiredDeliveryMediums=[],
-                #     MessageAction="SUPPRESS"
-                # )
 
                 print(f"Created user: {regional_username}")
 
@@ -141,6 +133,8 @@ def main():
                         f"Expect {game_connection_info['DnsName']} to contain '{REGION_US_WEST_2}'"
                     assert expected_game_session_region in game_connection_info['GameSessionArn'], \
                         f"Expect {game_connection_info['GameSessionArn']} to contain '{expected_game_session_region}'"
+                    assert "psess-" in game_connection_info['PlayerSessionId'], \
+                        f"Expect {game_connection_info['PlayerSessionId']} to contain 'psess-'"
                     print("Verified game connection info:", game_connection_info)
                     verified_players += 1
                 print(f"{verified_players} players' game sessions verified")

--- a/Editor/Resources/CloudFormation/scenario4_spot_fleets/lambda/game_session_event_handler.py
+++ b/Editor/Resources/CloudFormation/scenario4_spot_fleets/lambda/game_session_event_handler.py
@@ -27,6 +27,7 @@ def handler(event, context):
     dns_name = message['detail'].get('dnsName')
     port = message['detail'].get('port')
     game_session_arn = message['detail'].get('gameSessionArn')
+    player_sessions = message['detail'].get('placedPlayerSessions')
 
     game_session_placement_table_name = os.environ['GameSessionPlacementTableName']
 
@@ -41,6 +42,7 @@ def handler(event, context):
             'DnsName': dns_name,
             'Port': port,
             'GameSessionArn': game_session_arn,
-            'ExpirationTime': start_time + DEFAULT_TTL_IN_SECONDS
+            'ExpirationTime': start_time + DEFAULT_TTL_IN_SECONDS,
+            'PlayerSessions': player_sessions
         }
     )

--- a/Editor/Resources/CloudFormation/scenario4_spot_fleets/tests/test.py
+++ b/Editor/Resources/CloudFormation/scenario4_spot_fleets/tests/test.py
@@ -144,6 +144,8 @@ def main():
                         f"Expect {game_connection_info['DnsName']} to contain '{REGION_US_WEST_2}'"
                     assert expected_game_session_region in game_connection_info['GameSessionArn'], \
                         f"Expect {game_connection_info['GameSessionArn']} to contain '{expected_game_session_region}'"
+                    assert "psess-" in game_connection_info['PlayerSessionId'], \
+                        f"Expect {game_connection_info['PlayerSessionId']} to contain 'psess-'"
                     print("Verified game connection info:", game_connection_info)
                     verified_players += 1
                 print(f"{verified_players} players' game sessions verified")

--- a/Editor/Resources/CloudFormation/scenario5_flexmatch/lambda/flexmatch_status_poller.py
+++ b/Editor/Resources/CloudFormation/scenario5_flexmatch/lambda/flexmatch_status_poller.py
@@ -78,6 +78,12 @@ def handler(event, context):
                         }
                     })
                     if ticket_status == 'COMPLETED':
+                        # parse the playerSessionId
+                        matched_player_sessions = ticket.get('GameSessionConnectionInfo', {}).get('MatchedPlayerSessions')
+                        player_session_id = None
+                        if matched_player_sessions is not None and len(matched_player_sessions) == 1:
+                            player_session_id = matched_player_sessions[0].get('PlayerSessionId')
+
                         attribute_updates.update({
                             'IpAddress': {
                                 'Value': ticket.get('GameSessionConnectionInfo', {}).get('IpAddress')
@@ -90,6 +96,9 @@ def handler(event, context):
                             },
                             'GameSessionArn': {
                                 'Value': str(ticket.get('GameSessionConnectionInfo', {}).get('GameSessionArn'))
+                            },
+                            'PlayerSessionId': {
+                                'Value' : str(player_session_id)
                             }
                         })
                 else:

--- a/Editor/Resources/CloudFormation/scenario5_flexmatch/lambda/matchmaker_event_handler.py
+++ b/Editor/Resources/CloudFormation/scenario5_flexmatch/lambda/matchmaker_event_handler.py
@@ -39,6 +39,8 @@ def handler(event, context):
     dns_name = message['detail']['gameSessionInfo'].get('dnsName')
     port = str(message['detail']['gameSessionInfo'].get('port'))
     game_session_arn = str(message['detail']['gameSessionInfo'].get('gameSessionArn'))
+    players = message['detail']['gameSessionInfo']['players']
+    players_map = {player.get('playerId'):player.get('playerSessionId') for player in players}
 
     ticket_id_index_name = os.environ['TicketIdIndexName']
 
@@ -59,6 +61,8 @@ def handler(event, context):
 
         matchmaking_request_status = matchmaking_requests['Items'][0]['TicketStatus']
         player_id = matchmaking_requests['Items'][0]['PlayerId']
+        player_session_id = players_map.get(player_id)
+        print(f'Processing Ticket: {ticket_id}, PlayerId: {player_id}, PlayerSessionId: {player_session_id}')
         matchmaking_request_start_time = matchmaking_requests['Items'][0]['StartTime']
 
         if matchmaking_request_status != MATCHMAKING_STARTED_STATUS:
@@ -88,6 +92,9 @@ def handler(event, context):
                 },
                 'GameSessionArn': {
                     'Value': game_session_arn
+                },
+                'PlayerSessionId': {
+                    'Value': player_session_id
                 }
             })
 

--- a/Editor/Resources/CloudFormation/scenario5_flexmatch/lambda/results_request.py
+++ b/Editor/Resources/CloudFormation/scenario5_flexmatch/lambda/results_request.py
@@ -46,6 +46,9 @@ def handler(event, context):
         }
 
     latest_matchmaking_request = matchmaking_requests['Items'][0]
+
+    print(f'Current Matchmaking Request: {latest_matchmaking_request}')
+
     matchmaking_request_status = latest_matchmaking_request['TicketStatus']
 
     if matchmaking_request_status == MATCHMAKING_STARTED_STATUS:
@@ -58,7 +61,7 @@ def handler(event, context):
         }
     elif matchmaking_request_status == MATCHMAKING_SUCCEEDED_STATUS:
         game_session_connection_info = \
-            dict((k, latest_matchmaking_request[k]) for k in ('IpAddress', 'Port', 'DnsName', 'GameSessionArn'))
+            dict((k, latest_matchmaking_request[k]) for k in ('IpAddress', 'Port', 'DnsName', 'PlayerSessionId', 'GameSessionArn'))
         print(game_session_connection_info)
         return {
             'body': json.dumps(game_session_connection_info),

--- a/Editor/Resources/CloudFormation/scenario5_flexmatch/tests/test.py
+++ b/Editor/Resources/CloudFormation/scenario5_flexmatch/tests/test.py
@@ -144,6 +144,8 @@ def main():
                         f"Expect {game_connection_info['DnsName']} to contain '{REGION_US_WEST_2}'"
                     assert expected_game_session_region in game_connection_info['GameSessionArn'], \
                         f"Expect {game_connection_info['GameSessionArn']} to contain '{expected_game_session_region}'"
+                    assert "psess-" in game_connection_info['PlayerSessionId'], \
+                        f"Expect {game_connection_info['PlayerSessionId']} to contain 'psess-'"
                     print("Verified game connection info:", game_connection_info)
                     verified_players += 1
                 print(f"{verified_players} players' game sessions verified")

--- a/Runtime/Core/ApiGatewayManagement/AmazonGameLiftClientWrapper.cs
+++ b/Runtime/Core/ApiGatewayManagement/AmazonGameLiftClientWrapper.cs
@@ -32,6 +32,11 @@ namespace AmazonGameLiftPlugin.Core.ApiGatewayManagement
             return await _amazonGameLiftClient.CreateGameSessionAsync(request);
         }
 
+        public async Task<CreatePlayerSessionResponse> CreatePlayerSession(CreatePlayerSessionRequest request)
+        {
+            return await _amazonGameLiftClient.CreatePlayerSessionAsync(request);
+        }
+
         public async Task<SearchGameSessionsResponse> SearchGameSessions(SearchGameSessionsRequest request)
         {
             return await _amazonGameLiftClient.SearchGameSessionsAsync(request);

--- a/Runtime/Core/ApiGatewayManagement/ApiGateway.cs
+++ b/Runtime/Core/ApiGatewayManagement/ApiGateway.cs
@@ -159,6 +159,7 @@ namespace AmazonGameLiftPlugin.Core.ApiGatewayManagement
                         IpAddress = result.IpAddress,
                         DnsName = result.DnsName,
                         Port = result.Port,
+                        PlayerSessionId = result.PlayerSessionId,
                         IdToken = token
                     });
                 }

--- a/Runtime/Core/ApiGatewayManagement/IAmazonGameLiftClientWrapper.cs
+++ b/Runtime/Core/ApiGatewayManagement/IAmazonGameLiftClientWrapper.cs
@@ -14,6 +14,8 @@ namespace AmazonGameLiftPlugin.Core.ApiGatewayManagement
                 CancellationToken cancellationToken = default
             );
 
+        Task<CreatePlayerSessionResponse> CreatePlayerSession(CreatePlayerSessionRequest request);
+
         Task<SearchGameSessionsResponse> SearchGameSessions(SearchGameSessionsRequest request);
 
         Task<DescribeGameSessionsResponse> DescribeGameSessions(DescribeGameSessionsRequest request);

--- a/Runtime/Core/ApiGatewayManagement/LocalGameAdapter.cs
+++ b/Runtime/Core/ApiGatewayManagement/LocalGameAdapter.cs
@@ -14,6 +14,7 @@ namespace AmazonGameLiftPlugin.Core.ApiGatewayManagement
     {
         private readonly IAmazonGameLiftClientWrapper _amazonGameLiftClientWrapper;
         private readonly string _fleetId = "fleet-123";
+        private readonly string _playerIdPrefix = "playerId-";
 
         public LocalGameAdapter(IAmazonGameLiftClientWrapper amazonGameLiftClientWrapper)
         {
@@ -33,11 +34,19 @@ namespace AmazonGameLiftPlugin.Core.ApiGatewayManagement
                 {
                     Amazon.GameLift.Model.GameSession oldestGameSession = describeGameSessionsResponse.GameSessions.First();
 
+                    Amazon.GameLift.Model.CreatePlayerSessionResponse createPlayerSessionResponse = await _amazonGameLiftClientWrapper.CreatePlayerSession(new Amazon.GameLift.Model.CreatePlayerSessionRequest
+                    {
+                        GameSessionId = oldestGameSession.GameSessionId,
+                        PlayerId = _playerIdPrefix + Guid.NewGuid().ToString()
+                    });
+                    Amazon.GameLift.Model.PlayerSession playerSession = createPlayerSessionResponse.PlayerSession;
+
                     var response = new GetGameConnectionResponse
                     {
-                        IpAddress = oldestGameSession.IpAddress,
-                        DnsName = oldestGameSession.DnsName,
-                        Port = oldestGameSession.Port.ToString(),
+                        IpAddress = playerSession.IpAddress,
+                        DnsName = playerSession.DnsName,
+                        Port = playerSession.Port.ToString(),
+                        PlayerSessionId = playerSession.PlayerSessionId,
                         Ready = true
                     };
 

--- a/Runtime/Core/ApiGatewayManagement/Models/GetGameConnection.cs
+++ b/Runtime/Core/ApiGatewayManagement/Models/GetGameConnection.cs
@@ -16,6 +16,7 @@ namespace AmazonGameLiftPlugin.Core.ApiGatewayManagement.Models
         public string IpAddress { get; set; }
         public string DnsName { get; set; }
         public string Port { get; set; }
+        public string PlayerSessionId { get; set; }
         public bool Ready { get; set; }
     }
 }

--- a/Runtime/Core/ApiGatewayManagement/Models/GetGameConnectionResult.cs
+++ b/Runtime/Core/ApiGatewayManagement/Models/GetGameConnectionResult.cs
@@ -8,5 +8,6 @@ namespace AmazonGameLiftPlugin.Core.ApiGatewayManagement.Models
         public string IpAddress { get; set; }
         public string Port { get; set; }
         public string DnsName { get; set; }
+        public string PlayerSessionId { get; set; }
     }
 }

--- a/Samples~/SampleGame/Assets/Scripts/Client/NetworkClient.cs
+++ b/Samples~/SampleGame/Assets/Scripts/Client/NetworkClient.cs
@@ -6,6 +6,8 @@ using System;
 using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
+using UnityEngine;
+
 
 public class NetworkClient
 {
@@ -36,32 +38,32 @@ public class NetworkClient
         }
     }
 
-    public bool TryConnect(string ip, int port)
+    public bool TryConnect(ConnectionInfo connectionInfo)
     {
         try
         {
-            _client = new TcpClient(ip, port);
-            string msgStr = "CONNECT: server IP " + ip;
+            _client = new TcpClient(connectionInfo.IpAddress, connectionInfo.Port);
+            string msgStr = "CONNECT:" + connectionInfo.Serialize();
             NetworkProtocol.Send(_client, msgStr);
             return true;
         }
         catch (ArgumentNullException e)
         {
             _client = null;
-            _gl.Log.WriteLine(":( CONNECT TO SERVER " + ip + " FAILED: " + e);
+            _gl.Log.WriteLine(":( CONNECT TO SERVER " + connectionInfo.IpAddress + " FAILED: " + e);
             return false;
         }
         catch (SocketException e) // server not available
         {
             _client = null;
 
-            if (ip == LocalHost)
+            if (connectionInfo.IpAddress == LocalHost)
             {
                 _gl.Log.WriteLine(":) CONNECT TO LOCAL SERVER FAILED: PROBABLY NO LOCAL SERVER RUNNING, TRYING GAMELIFT");
             }
             else
             {
-                _gl.Log.WriteLine(":( CONNECT TO SERVER " + ip + "FAILED: " + e + " (ARE YOU ON THE *AMAZON*INTERNAL*NETWORK*?)");
+                _gl.Log.WriteLine(":( CONNECT TO SERVER " + connectionInfo.IpAddress + "FAILED: " + e + " (ARE YOU ON THE *AMAZON*INTERNAL*NETWORK*?)");
             }
 
             return false;

--- a/Samples~/SampleGame/Assets/Scripts/ConnectionInfo.cs
+++ b/Samples~/SampleGame/Assets/Scripts/ConnectionInfo.cs
@@ -1,0 +1,56 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+using UnityEngine;
+
+[System.Serializable]
+public class ConnectionInfo
+{
+    [SerializeField]
+    private string _ipAddress;
+    [SerializeField]
+    private int _port;
+    [SerializeField]
+    private string _playerSessionId;
+
+    public string IpAddress
+    {
+        get { return _ipAddress; }
+        set { _ipAddress = value; }
+    }
+    public int Port
+    {
+        get { return _port; }
+        set { _port = value; }
+    }
+    public string PlayerSessionId
+    {
+        get { return _playerSessionId; }
+        set { _playerSessionId = value; }
+    }
+
+    public string Serialize()
+    {
+        return JsonUtility.ToJson(this);
+    }
+
+    public static ConnectionInfo CreateFromSerial(string json)
+    {
+        var temp = new ConnectionInfo();
+        temp.Deserialize(json);
+        return temp;
+    }
+
+    public override string ToString()
+    {
+        return string.Format("ConnectionInfo (IpAddress: {0}, Port: {1}, PlayerSessionId: {2})", IpAddress, Port, PlayerSessionId); 
+    }
+
+    private void Deserialize(string json)
+    {
+        if (!string.IsNullOrEmpty(json))
+        {
+            JsonUtility.FromJsonOverwrite(json, this);
+        }
+    }
+}

--- a/Samples~/SampleGame/Assets/Scripts/ConnectionInfo.cs.meta
+++ b/Samples~/SampleGame/Assets/Scripts/ConnectionInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 75d536d99f1a4ed4e8f46511caf5279d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Samples~/SampleGame/Assets/Scripts/GameLogic.cs
+++ b/Samples~/SampleGame/Assets/Scripts/GameLogic.cs
@@ -103,6 +103,8 @@ public class GameLogic : MonoBehaviour
         Render = new Render();
 #if UNITY_SERVER
         _server = new NetworkServer(this, GameLift.ServerPort);
+        // if running server, GameLift is already initialized before GameLogic.Start is called
+        GameliftStatus = GameLift.IsConnected;
         _logger.Write(":) LISTENING ON PORT " + GameLift.ServerPort);
 #else
         _client = new NetworkClient(this);
@@ -189,12 +191,12 @@ public class GameLogic : MonoBehaviour
             startGameScreen.SetInteractable(false);
             startGameScreen.SetResultText(string.Empty);
 
-            (bool success, string ip, int port) = await GameLift.GetConnectionInfo(cancellationToken);
+            (bool success, ConnectionInfo connectionInfo) = await GameLift.GetConnectionInfo(cancellationToken);
 
             if (success)
             {
-                GameliftStatus = ip != NetworkClient.LocalHost;
-                ClientConnected = _client.TryConnect(ip, port);
+                GameliftStatus = connectionInfo.IpAddress != NetworkClient.LocalHost;
+                ClientConnected = _client.TryConnect(connectionInfo);
             }
 
             if (!ClientConnected)

--- a/Samples~/SampleGame/Assets/Scripts/Server/GameLiftServer.cs
+++ b/Samples~/SampleGame/Assets/Scripts/Server/GameLiftServer.cs
@@ -90,6 +90,54 @@ public class GameLiftServer
         }
     }
 
+    public bool AcceptPlayerSession(string playerSessionId)
+    {
+        try
+        {
+            GenericOutcome outcome = GameLiftServerAPI.AcceptPlayerSession(playerSessionId);
+
+            if (outcome.Success)
+            {
+                _logger.Write(":) Accepted Player Session: " + playerSessionId);
+                return true;
+            }
+            else
+            {
+                _logger.Write(":( ACCEPT PLAYER SESSION FAILED. AcceptPlayerSession() returned " + outcome.Error.ToString());
+                return false;
+            }
+        }
+        catch (Exception e)
+        {
+            _logger.Write(":( ACCEPT PLAYER SESSION FAILED. AcceptPlayerSession() exception " + Environment.NewLine + e.Message);
+            return false;
+        }
+    }
+
+    public bool RemovePlayerSession(string playerSessionId)
+    {
+        try
+        {
+            GenericOutcome outcome = GameLiftServerAPI.RemovePlayerSession(playerSessionId);
+
+            if (outcome.Success)
+            {
+                _logger.Write(":) Removed Player Session: " + playerSessionId);
+                return true;
+            }
+            else
+            {
+                _logger.Write(":( REMOVE PLAYER SESSION FAILED. RemovePlayerSession() returned " + outcome.Error.ToString());
+                return false;
+            }
+        }
+        catch (Exception e)
+        {
+            _logger.Write(":( REMOVE PLAYER SESSION FAILED. RemovePlayerSession() exception " + Environment.NewLine + e.Message);
+            return false;
+        }
+    }
+
     private void ProcessReady()
     {
         try

--- a/Samples~/SampleGame/Assets/Tests/Editor/Unit/GameLiftClientTests.cs
+++ b/Samples~/SampleGame/Assets/Tests/Editor/Unit/GameLiftClientTests.cs
@@ -54,7 +54,7 @@ namespace SampleTests.Unit
                 };
 
                 // Act
-                (bool success, string _, int _) = await underTest.GetConnectionInfo();
+                (bool success, ConnectionInfo _) = await underTest.GetConnectionInfo();
 
                 // Assert
                 coreApiMock.Verify();
@@ -90,7 +90,7 @@ namespace SampleTests.Unit
                 };
 
                 // Act
-                (bool success, string ip, int port) = await underTest.GetConnectionInfo();
+                (bool success, ConnectionInfo connectionInfo) = await underTest.GetConnectionInfo();
 
                 // Assert
                 coreApiMock.Verify();
@@ -123,6 +123,7 @@ namespace SampleTests.Unit
             {
                 const string testIp = "testIp";
                 const string testPort = "8080";
+                const string testPlayerSessionId = "psess-123";
 
                 var delayMock = new Mock<Delay>();
                 SetUpDelayMockWait(delayMock);
@@ -136,6 +137,7 @@ namespace SampleTests.Unit
                     IdToken = _credentials.IdToken,
                     IpAddress = testIp,
                     Port = testPort,
+                    PlayerSessionId = testPlayerSessionId,
                     Ready = false,
                 });
                 GetGameConnectionResponse connectionReadyResponse = Response.Ok(new GetGameConnectionResponse
@@ -143,6 +145,7 @@ namespace SampleTests.Unit
                     IdToken = _credentials.IdToken,
                     IpAddress = testIp,
                     Port = testPort,
+                    PlayerSessionId = testPlayerSessionId,
                     Ready = true,
                 });
 
@@ -162,7 +165,7 @@ namespace SampleTests.Unit
                 };
 
                 // Act
-                (bool success, string ip, int port) info = await underTest.GetConnectionInfo();
+                (bool success, ConnectionInfo connectionInfo) info = await underTest.GetConnectionInfo();
 
                 // Assert
                 coreApiMock.Verify();
@@ -171,8 +174,9 @@ namespace SampleTests.Unit
 
                 if (success)
                 {
-                    Assert.AreEqual(testIp, info.ip);
-                    Assert.AreEqual(testPort, info.port.ToString());
+                    Assert.AreEqual(testIp, info.connectionInfo.IpAddress);
+                    Assert.AreEqual(testPort, info.connectionInfo.Port.ToString());
+                    Assert.AreEqual(testPlayerSessionId, info.connectionInfo.PlayerSessionId);
                 }
             }
         }
@@ -214,12 +218,12 @@ namespace SampleTests.Unit
                 };
 
                 // Act
-                (bool success, string ip, int port) info = await underTest.GetConnectionInfo();
+                (bool success, ConnectionInfo connectionInfo) info = await underTest.GetConnectionInfo();
 
                 // Assert
                 coreApiMock.Verify();
                 delayMock.Verify();
-                Assert.AreEqual(testDns, info.ip);
+                Assert.AreEqual(testDns, info.connectionInfo.IpAddress);
             }
         }
 

--- a/Tests/Runtime/Core/ApiGateWayManagement/ApiGatewayTests.cs
+++ b/Tests/Runtime/Core/ApiGateWayManagement/ApiGatewayTests.cs
@@ -37,7 +37,7 @@ namespace AmazonGameLiftPlugin.Core.Tests.ApiGateWayManagement
 
             httpClientMock.Setup(x =>
             x.Post(request.ApiGatewayEndpoint, "RefreshedIdToken", "get_game_connection", null))
-                .ReturnsAsync((HttpStatusCode.OK, @"{""port"":""1"",""ipAddress"":""1.1""}"));
+                .ReturnsAsync((HttpStatusCode.OK, @"{""port"":""1"",""ipAddress"":""1.1"", ""playerSessionId"": ""psess-123""}"));
 
             var sut = new ApiGateway(
                     userIdentity.Object,
@@ -50,6 +50,7 @@ namespace AmazonGameLiftPlugin.Core.Tests.ApiGateWayManagement
             Assert.IsTrue(response.Success);
             Assert.AreEqual("1", response.Port);
             Assert.AreEqual("1.1", response.IpAddress);
+            Assert.AreEqual("psess-123", response.PlayerSessionId);
             Assert.AreEqual("RefreshedIdToken", response.IdToken);
             tokenHandler.Verify();
             httpClientMock.Verify();

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "com.amazonaws.gamelift",
   "displayName": "Amazon GameLift Plugin for Unity",
   "author": "Amazon.com, Inc.",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "unity": "2019.4",
   "description": "The Amazon GameLift Plugin for Unity contains libraries and native UI that makes it easier to access GameLift resources and integrate GameLift into your Unity game. You can use the GameLift Unity Plugin to access GameLift APIs and deploy AWS CloudFormation templates for common gaming scenarios.",
   "documentationUrl": "https://docs.aws.amazon.com/gamelift/latest/developerguide/unity-plug-in.html",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
```
# 1.1.1 (10/13/2021)
- Deployment Scenario
    - Add support to create player session in "Single Region Fleet" deployment scenario
	- Pass back player session ID in all get_game_connection responses
- Sample Game
    - Sample game client now accepts player session ID from get_game_connection responses and pass it to the game server
	  after establishing a connection
    - Sample game server now accepts player session ID from client and call AcceptPlayerSession with the provided ID. 
	  This fixes deployment scenarios not accounting for fulfilled player session slots
- Testing
    - Added assembly definition to run plugin unit tests via the Unity test runner
	- Fixed some unit tests
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
