### PR TITLE
Use explicit DLL name in ping sdk to support Mac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 CHANGELOG
 
+# 1.2.1 (11/15/2021)
+
+- Mac OS Support
+    - Fix "Ping SDK" button not showing the SDK DLL in Mac OS
+
 # 1.1.1 (10/13/2021)
 
 - Deployment Scenario

--- a/Editor/CoreAPI/Paths.cs
+++ b/Editor/CoreAPI/Paths.cs
@@ -12,6 +12,6 @@ namespace AmazonGameLift.Editor
         public const string LambdaFolderPathInScenario = "lambda";
         public const string CfnTemplateFileName = "cloudformation.yml";
         public const string ParametersFileName = "parameters.json";
-        public const string ServerSdkDllInPackage = "Runtime/Plugins/GameLiftServerSDK";
+        public const string ServerSdkDllInPackage = "Runtime/Plugins/GameLiftServerSDKNet45.dll";
     }
 }

--- a/Editor/EditorMenu.cs
+++ b/Editor/EditorMenu.cs
@@ -82,6 +82,9 @@ namespace AmazonGameLift.Editor
             {
                 Selection.activeObject = sdk;
                 EditorGUIUtility.PingObject(sdk);
+            } else {
+                Debug.LogError($"Cannot find GameLift SDK DLL in asset path: {filePackagePath}. "
+                        + "Try downloading the Plugin package and import again.");
             }
         }
     }


### PR DESCRIPTION
*Issue #, if available:* #45

*Description of changes:*

* Fix "Ping SDK" button not showing the SDK DLL in Mac OS

Tested in both Windows and Mac

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
