### PR TITLE
Open project browser when pinging SDK DLLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@
 *.dll
 *.unitypackage
 *.tgz
-*.tgz.meta
+*.meta
 SampleGameBuildLog.txt

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,7 @@
 *.dll
 *.unitypackage
 *.tgz
-*.meta
+*.tgz.meta
+*.iml
+*.iml.meta
 SampleGameBuildLog.txt

--- a/Editor/EditorMenu.cs
+++ b/Editor/EditorMenu.cs
@@ -77,10 +77,22 @@ namespace AmazonGameLift.Editor
         {
             string filePackagePath = $"Packages/{Paths.PackageName}/{Paths.ServerSdkDllInPackage}";
             UnityEngine.Object sdk = AssetDatabase.LoadMainAssetAtPath(filePackagePath);
+            Type projectBrowser = typeof(UnityEditor.Editor).Assembly.GetType("UnityEditor.ProjectBrowser");
 
-            if (sdk)
+            if (projectBrowser != null) {
+                // Show Project Browser window
+                EditorWindow.GetWindow(projectBrowser).Show();
+            } else {
+                Debug.LogError($"Cannot open the Unity Project Browser window.");
+                return;
+            }
+
+            if (sdk != null)
             {
+                // Show SDK DLL in Unity Inspector
                 Selection.activeObject = sdk;
+
+                // Highlight SDK DLL in Unity Project Browser
                 EditorGUIUtility.PingObject(sdk);
             } else {
                 Debug.LogError($"Cannot find GameLift SDK DLL in asset path: {filePackagePath}. "


### PR DESCRIPTION
*Issue #, if available:* #45 

*Description of changes:*
Open project browser when pinging SDK DLLs to improve user experience

Tested on both Windows and Mac

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
