### PR TITLE
Support JRE/JDK detection for Mac OS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 
 - Mac OS Support
     - Fix "Ping SDK" button not showing the SDK DLL in Mac OS
+    - Fix JRE/JDK not detectable in Mac OS
 
 # 1.1.1 (10/13/2021)
 

--- a/Editor/PluginSettings/SettingsState.cs
+++ b/Editor/PluginSettings/SettingsState.cs
@@ -28,12 +28,8 @@ namespace AmazonGameLift.Editor
             _settings.CredentialsSetting.IsConfigured
             && _settings.BootstrapSetting.IsConfigured;
 
-        // TODO (GLIFT-15531, issue #9) Re-enable JRE/JDK check to enable local testing UI
-        // See: https://github.com/awslabs/amazon-gamelift-plugin-unity/issues/9
-        // public bool CanRunLocalTest => _settings.GameLiftLocalSetting.IsConfigured
-        //     && _settings.JavaSetting.IsConfigured;
-        public bool CanRunLocalTest =>
-            _settings.GameLiftLocalSetting.IsConfigured;
+        public bool CanRunLocalTest => _settings.GameLiftLocalSetting.IsConfigured
+            && _settings.JavaSetting.IsConfigured;
 
         public SettingsState(Settings settings, TextProvider textProvider)
         {

--- a/Runtime/Core/InstalledJavaVersionCheck/InstalledJavaVersionProvider.cs
+++ b/Runtime/Core/InstalledJavaVersionCheck/InstalledJavaVersionProvider.cs
@@ -23,7 +23,7 @@ namespace AmazonGameLiftPlugin.Core.JavaCheck
         public CheckInstalledJavaVersionResponse CheckInstalledJavaVersion(CheckInstalledJavaVersionRequest request)
         {
             var processStartInfo = new ProcessStartInfo();
-            processStartInfo.FileName = "java.exe";
+            processStartInfo.FileName = "java";
             processStartInfo.Arguments = " -version";
             processStartInfo.RedirectStandardError = true;
             processStartInfo.UseShellExecute = false;


### PR DESCRIPTION
*Issue #, if available:* #9 #45

*Description of changes:*
Support JRE/JDK detection for Mac OS

Tested on both Windows and Mac

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
