### PR TITLE
Restrict server executable path to 'exe' extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 - Mac OS Support
     - Fix "Ping SDK" button not showing the SDK DLL in Mac OS
     - Fix JRE/JDK not detectable in Mac OS
+    - Fix ".exe" extension not selectable for server build executable path in Mac OS
 
 # 1.1.1 (10/13/2021)
 

--- a/Editor/Deployment/DeploymentWindow.cs
+++ b/Editor/Deployment/DeploymentWindow.cs
@@ -231,7 +231,7 @@ namespace AmazonGameLift.Editor
             {
                 _model.BuildFolderPath = _controlDrawer.DrawFolderPathField(_labelBuildFolderPath,
                     _model.BuildFolderPath, _labelDefaultFolderName, _titleServerFolderDialog);
-                _model.BuildFilePath = _controlDrawer.DrawFilePathField(_labelBuildFilePath, _model.BuildFilePath, "*", _titleServerFileDialog);
+                _model.BuildFilePath = _controlDrawer.DrawFilePathField(_labelBuildFilePath, _model.BuildFilePath, "exe", _titleServerFileDialog);
             }
 
             GUILayout.Space(VerticalSpacingPixels);


### PR DESCRIPTION
*Issue #, if available:* #45

*Description of changes:*
In Mac OS, "*" extension is not recognized as a wildcard unlike windows. Restricting this to "exe" since we only support Windows fleet build for now.

Tested in both windows and mac.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
