### PR TITLE
Support local testing with Mac sample server and GameLift Local

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ CHANGELOG
     - Fix "Ping SDK" button not showing the SDK DLL in Mac OS
     - Fix JRE/JDK not detectable in Mac OS
     - Fix ".exe" extension not selectable for server build executable path in Mac OS
+    - Support building sample game server and client on Mac OS platform
+    - Support ".app" for game server executable file extension in local testing
+    - Support starting/stopping local testing in Mac OS terminal app
 
 # 1.1.1 (10/13/2021)
 

--- a/Editor/CoreAPI/CoreApi.cs
+++ b/Editor/CoreAPI/CoreApi.cs
@@ -485,31 +485,38 @@ namespace AmazonGameLift.Editor
 
         private readonly GameLiftProcess _gameLiftProcess = new GameLiftProcess(s_process);
 
-        public virtual StartResponse StartGameLiftLocal(string gameLiftLocalFilePath, int port)
+        public virtual StartResponse StartGameLiftLocal(string gameLiftLocalFilePath, int port,
+                LocalOperatingSystem localOperatingSystem = LocalOperatingSystem.WINDOWS)
         {
             var request = new StartRequest()
             {
                 GameLiftLocalFilePath = gameLiftLocalFilePath,
-                Port = port
+                Port = port,
+                LocalOperatingSystem = localOperatingSystem
             };
             return _gameLiftProcess.Start(request);
         }
 
-        public virtual StopResponse StopProcess(int processId)
+        public virtual StopResponse StopProcess(int processId,
+                LocalOperatingSystem localOperatingSystem = LocalOperatingSystem.WINDOWS)
         {
             var request = new StopRequest()
             {
-                ProcessId = processId
+                ProcessId = processId,
+                LocalOperatingSystem = localOperatingSystem
             };
             return _gameLiftProcess.Stop(request);
         }
 
-        public virtual RunLocalServerResponse RunLocalServer(string exeFilePath)
+        public virtual RunLocalServerResponse RunLocalServer(string exeFilePath, string applicationProductName,
+                LocalOperatingSystem localOperatingSystem = LocalOperatingSystem.WINDOWS)
         {
             var request = new RunLocalServerRequest()
             {
                 FilePath = exeFilePath,
                 ShowWindow = true,
+                ApplicationProductName = applicationProductName,
+                LocalOperatingSystem = localOperatingSystem
             };
             return _gameLiftProcess.RunLocalServer(request);
         }

--- a/Editor/LocalTest/LocalTestWindow.cs
+++ b/Editor/LocalTest/LocalTestWindow.cs
@@ -116,8 +116,8 @@ namespace AmazonGameLift.Editor
 
             using (new EditorGUI.DisabledScope(_model.IsDeploymentRunning))
             {
-                _model.BuildExePath = _controlDrawer.DrawFilePathField(
-                  _labelServerPath, _model.BuildExePath, "exe", _titleServerPathDialog,
+                _model.BuildExecutablePath = _controlDrawer.DrawFilePathField(
+                  _labelServerPath, _model.BuildExecutablePath, "exe,app", _titleServerPathDialog,
                   _tooltipLocalTestingServerPath);
 
                 GUILayout.Space(VerticalSpacingPixels);

--- a/Editor/OperatingSystemUtility.cs
+++ b/Editor/OperatingSystemUtility.cs
@@ -1,0 +1,37 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using UnityEngine;
+using AmazonGameLiftPlugin.Core.GameLiftLocalTesting.Models;
+
+namespace AmazonGameLift.Editor
+{
+    // See available operating system types: https://docs.unity3d.com/ScriptReference/SystemInfo-operatingSystem.html
+    internal class OperatingSystemUtility
+    {
+        public static LocalOperatingSystem GetLocalOperatingSystem()
+        {
+            if (isMacOs())
+            {
+                return LocalOperatingSystem.MAC_OS;
+            }
+
+            if (isWindows())
+            {
+                return LocalOperatingSystem.WINDOWS;
+            }
+
+            return LocalOperatingSystem.UNSUPPORTED;
+        }
+
+        public static bool isMacOs()
+        {
+            return SystemInfo.operatingSystem.StartsWith("Mac OS");
+        }
+
+        public static bool isWindows()
+        {
+            return SystemInfo.operatingSystem.StartsWith("Windows");
+        }
+    }
+}

--- a/Editor/OperatingSystemUtility.cs.meta
+++ b/Editor/OperatingSystemUtility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: acf43cf385b7c46fd8ace1f5df3dfa85
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/TextProvider.cs
+++ b/Editor/TextProvider.cs
@@ -184,7 +184,7 @@ namespace AmazonGameLift.Editor
             { Strings.TooltipSettingsAwsCredentials, "Setup credentials used for account bootstrapping and CloudFormation deployment."},
             { Strings.TooltipSettingsBootstrap, "Create an S3 bucket to store GameLift build artifacts and lambda function source code."},
             { Strings.TooltipSettingsDotNet, "Opt in to change \"API Compatibility Level\" of the project to 4.x, which is the latest version of .NET Framework API that the current GameLift Server SDK supports."},
-            { Strings.TooltipSettingsJava, "Download and install the latest Java Runtime Environment (JRE) in order to run GameLift Local.\nNOTE: If you have JDK installed, this may show as \"Not Configured\", but local testing will work as long as you have \"java.exe\" in your PATH environment variable"},
+            { Strings.TooltipSettingsJava, "Download and install the latest Java Runtime Environment (JRE) in order to run GameLift Local.\nNOTE: If you have JDK installed, this may show as \"Not Configured\", but local testing will work as long as you have \"java\" in your PATH environment variable"},
             { Strings.TooltipSettingsLocalTesting, "Download the GameLift Local jar bundled in \"Managed GameLift Server SDK\" on AWS website, the set the GameLift Local Path to GameLiftLocal.jar in the extracted files.\nNOTE: \"Download GameLift Local\" opens your browser to download a ZIP file from AWS website to your system's Download folder."},
             { Strings.TooltipBootstrapBucketLifecycle, "Specify an expiration date of your S3 bucket."},
             { Strings.TooltipBootstrapCurrentBucket, "This is the name of the S3 bucket which is used currently."},

--- a/Runtime/AmazonGameLiftPlugin.Runtime.asmdef
+++ b/Runtime/AmazonGameLiftPlugin.Runtime.asmdef
@@ -6,7 +6,9 @@
     ],
     "includePlatforms": [
         "Editor",
-        "WindowsStandalone64"
+        "WindowsStandalone64",
+        "macOSStandalone",
+        "LinuxStandalone64"
     ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,

--- a/Runtime/Core/GameLiftLocalTesting/Models/LocalOperatingSystem.cs
+++ b/Runtime/Core/GameLiftLocalTesting/Models/LocalOperatingSystem.cs
@@ -5,15 +5,10 @@ using AmazonGameLiftPlugin.Core.Shared;
 
 namespace AmazonGameLiftPlugin.Core.GameLiftLocalTesting.Models
 {
-    public class StopRequest
+    public enum LocalOperatingSystem
     {
-        public int ProcessId { get; set; }
-
-        public LocalOperatingSystem LocalOperatingSystem { get; set; }
-    }
-
-    public class StopResponse : Response
-    {
-
+        WINDOWS,
+        MAC_OS,
+        UNSUPPORTED
     }
 }

--- a/Runtime/Core/GameLiftLocalTesting/Models/LocalOperatingSystem.cs.meta
+++ b/Runtime/Core/GameLiftLocalTesting/Models/LocalOperatingSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d5e2464dc93e64f69ac0c61e2fe61915
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Core/GameLiftLocalTesting/Models/RunLocalServer.cs
+++ b/Runtime/Core/GameLiftLocalTesting/Models/RunLocalServer.cs
@@ -9,6 +9,8 @@ namespace AmazonGameLiftPlugin.Core.GameLiftLocalTesting.Models
     {
         public string FilePath { get; set; }
         public bool ShowWindow { get; set; }
+        public string ApplicationProductName { get; set; }
+        public LocalOperatingSystem LocalOperatingSystem { get; set; }
     }
 
     public class RunLocalServerResponse : Response

--- a/Runtime/Core/GameLiftLocalTesting/Models/Start.cs
+++ b/Runtime/Core/GameLiftLocalTesting/Models/Start.cs
@@ -10,6 +10,8 @@ namespace AmazonGameLiftPlugin.Core.GameLiftLocalTesting.Models
         public string GameLiftLocalFilePath { get; set; }
 
         public int Port { get; set; }
+
+        public LocalOperatingSystem LocalOperatingSystem { get; set; }
     }
 
     public class StartResponse : Response

--- a/Runtime/Core/Shared/ProcessManagement/IProcessWrapper.cs
+++ b/Runtime/Core/Shared/ProcessManagement/IProcessWrapper.cs
@@ -9,6 +9,8 @@ namespace AmazonGameLiftPlugin.Core.Shared.ProcessManagement
     {
         string GetProcessOutput(ProcessStartInfo startInfo);
 
+        (int, string) GetProcessIdAndStandardOutput(ProcessStartInfo startInfo);
+
         int Start(ProcessStartInfo processStartInfo);
 
         void Kill(int processId);

--- a/Runtime/Core/Shared/ProcessManagement/ProcessWrapper.cs
+++ b/Runtime/Core/Shared/ProcessManagement/ProcessWrapper.cs
@@ -15,6 +15,13 @@ namespace AmazonGameLiftPlugin.Core.Shared.ProcessManagement
             return process.Id;
         }
 
+        public (int, string) GetProcessIdAndStandardOutput(ProcessStartInfo startInfo)
+        {
+            var process = Process.Start(startInfo);
+
+            return (process.Id, process.StandardOutput.ReadLine());
+        }
+
         public string GetProcessOutput(ProcessStartInfo startInfo)
         {
             try

--- a/Samples~/SampleGame/Assets/Scripts/SampleGame.asmdef
+++ b/Samples~/SampleGame/Assets/Scripts/SampleGame.asmdef
@@ -7,7 +7,9 @@
     "optionalUnityReferences": [],
     "includePlatforms": [
         "Editor",
-        "WindowsStandalone64"
+        "WindowsStandalone64",
+        "macOSStandalone",
+        "LinuxStandalone64"
     ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,


### PR DESCRIPTION
*Issue #, if available:* #45

*Description of changes:*
    * Support starting/closing Mac Terminal windows for GameLift Local and Game Server
    * Support running .app local server
    * Support sample game in Mac platform
    * Add editor utility to identify OS
    * Accept OS as request parameter in core library process APIs


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
