### PR TITLE
Account for multiline output when calling "java -version"

### DIFF
--- a/Runtime/Core/InstalledJavaVersionCheck/InstalledJavaVersionProvider.cs
+++ b/Runtime/Core/InstalledJavaVersionCheck/InstalledJavaVersionProvider.cs
@@ -68,7 +68,7 @@ namespace AmazonGameLiftPlugin.Core.JavaCheck
             //  if majorVersion is 1, we use minorVersion as the majorVersion, since java version had the format 1.?? until java 8
             var majorVersion = outputMatch.Groups["majorVersion"].ToString();
             var minorVersion = outputMatch.Groups["minorVersion"].ToString();
-            var actualMajorVersion = majorVersion.Equals("1") ? minorVersion : majorVersion;
+            var actualMajorVersion = majorVersion.Equals("1") && !String.IsNullOrEmpty(minorVersion) ? minorVersion : majorVersion;
 
             int.TryParse(actualMajorVersion, out int majorVersionAsNumber);
             bool isInstalled = majorVersionAsNumber >= request.ExpectedMinimumJavaMajorVersion;

--- a/Runtime/Core/InstalledJavaVersionCheck/InstalledJavaVersionProvider.cs
+++ b/Runtime/Core/InstalledJavaVersionCheck/InstalledJavaVersionProvider.cs
@@ -20,7 +20,7 @@ namespace AmazonGameLiftPlugin.Core.JavaCheck
             _process = process;
         }
 
-        private CheckInstalledJavaVersionResponse makeResponse(bool installed) {
+        private CheckInstalledJavaVersionResponse CreateCheckInstalledJavaVersionResponse(bool installed) {
             return Response.Ok(new CheckInstalledJavaVersionResponse
                 {
                     IsInstalled = installed
@@ -44,11 +44,11 @@ namespace AmazonGameLiftPlugin.Core.JavaCheck
             catch (Exception ex)
             {
                 Logger.LogError(ex, ex.Message);
-                return makeResponse(false);
+                return CreateCheckInstalledJavaVersionResponse(false);
             }
 
             if (processOutput == null) {
-                return makeResponse(false);
+                return CreateCheckInstalledJavaVersionResponse(false);
             }
 
             // Expected output format:
@@ -62,7 +62,7 @@ namespace AmazonGameLiftPlugin.Core.JavaCheck
             Match outputMatch = outputPattern.Match(processOutput);
 
             if (!outputMatch.Success) {
-                return makeResponse(false);
+                return CreateCheckInstalledJavaVersionResponse(false);
             }
 
             //  if majorVersion is 1, we use minorVersion as the majorVersion, since java version had the format 1.?? until java 8
@@ -70,10 +70,10 @@ namespace AmazonGameLiftPlugin.Core.JavaCheck
             var minorVersion = outputMatch.Groups["minorVersion"].ToString();
             var actualMajorVersion = majorVersion.Equals("1") ? minorVersion : majorVersion;
 
-            bool majorVersionParsed = int.TryParse(actualMajorVersion, out int majorVersionAsNumber);
+            int.TryParse(actualMajorVersion, out int majorVersionAsNumber);
             bool isInstalled = majorVersionAsNumber >= request.ExpectedMinimumJavaMajorVersion;
 
-            return makeResponse(isInstalled);
+            return CreateCheckInstalledJavaVersionResponse(isInstalled);
         }
     }
 }

--- a/Runtime/Core/InstalledJavaVersionCheck/InstalledJavaVersionProvider.cs
+++ b/Runtime/Core/InstalledJavaVersionCheck/InstalledJavaVersionProvider.cs
@@ -44,7 +44,7 @@ namespace AmazonGameLiftPlugin.Core.JavaCheck
                 });
             }
 
-            var outputPattern = new Regex("\\d+\\.\\d+\\.\\d+(?:_\\d+)?\"");
+            var outputPattern = new Regex("(openjdk|java) version \"(\\d+\\.\\d+\\.\\d+(?:_\\d+)?)\"");
 
             Match outputMatch = outputPattern.Match(processOutput);
 
@@ -57,10 +57,11 @@ namespace AmazonGameLiftPlugin.Core.JavaCheck
             }
 
             // example output: java version "1.8.0"
-            string[] outputWords = processOutput
+            var versionLine = outputMatch.Groups[0].ToString();
+            string[] outputWords = versionLine
                 .Split(' ');
 
-            if (outputWords.Length < 3)
+            if (versionLine.Length < 3)
             {
                 return Response.Ok(new CheckInstalledJavaVersionResponse
                 {

--- a/Runtime/Core/Shared/ProcessManagement/IProcessWrapper.cs
+++ b/Runtime/Core/Shared/ProcessManagement/IProcessWrapper.cs
@@ -7,7 +7,7 @@ namespace AmazonGameLiftPlugin.Core.Shared.ProcessManagement
 {
     public interface IProcessWrapper
     {
-        string GetProcessOutput(ProcessStartInfo startInfo);
+        string? GetProcessOutput(ProcessStartInfo startInfo);
 
         (int, string) GetProcessIdAndStandardOutput(ProcessStartInfo startInfo);
 

--- a/Runtime/Core/Shared/ProcessManagement/ProcessWrapper.cs
+++ b/Runtime/Core/Shared/ProcessManagement/ProcessWrapper.cs
@@ -26,9 +26,7 @@ namespace AmazonGameLiftPlugin.Core.Shared.ProcessManagement
         {
             try
             {
-                return Process.Start(startInfo)
-                .StandardError
-                .ReadLine();
+                return Process.Start(startInfo)?.StandardError?.ReadToEnd() ?? "";
             }
             catch (Win32Exception ex)
             {

--- a/Runtime/Core/Shared/ProcessManagement/ProcessWrapper.cs
+++ b/Runtime/Core/Shared/ProcessManagement/ProcessWrapper.cs
@@ -22,11 +22,11 @@ namespace AmazonGameLiftPlugin.Core.Shared.ProcessManagement
             return (process.Id, process.StandardOutput.ReadLine());
         }
 
-        public string GetProcessOutput(ProcessStartInfo startInfo)
+        public string? GetProcessOutput(ProcessStartInfo startInfo)
         {
             try
             {
-                return Process.Start(startInfo)?.StandardError?.ReadToEnd() ?? "";
+                return Process.Start(startInfo)?.StandardError?.ReadToEnd();
             }
             catch (Win32Exception ex)
             {

--- a/Tests/Runtime/Core/InstalledJavaVersionCheck/InstalledJavaVersionProviderTests.cs
+++ b/Tests/Runtime/Core/InstalledJavaVersionCheck/InstalledJavaVersionProviderTests.cs
@@ -75,6 +75,15 @@ namespace AmazonGameLiftPlugin.Core.Tests.InstalledJavaVersionCheck
         }
 
         [Test]
+        public void CheckInstalledJavaVersion_WithSecurityPatch()
+        {
+            var output = "java version \"9.1.1.1\"";
+            var response = GetCheckInstalledJavaVersionResponse(output, 8);
+            Assert.IsTrue(response.Success, "Request was not successful");
+            Assert.IsTrue(response.IsInstalled);
+        }
+
+        [Test]
         public void CheckInstalledJavaVersion_WhenJavaVersionIsTooLow()
         {
             var output = "java version \"1.8.0_291\"";

--- a/Tests/Runtime/Core/InstalledJavaVersionCheck/InstalledJavaVersionProviderTests.cs
+++ b/Tests/Runtime/Core/InstalledJavaVersionCheck/InstalledJavaVersionProviderTests.cs
@@ -40,7 +40,7 @@ namespace AmazonGameLiftPlugin.Core.Tests.InstalledJavaVersionCheck
         {
             string output = @"
                 Picked up JAVA_TOOL_OPTIONS: -Dlog4j2.formatMsgNoLookups=true
-                java version ""1.8.0_291""
+                openjdk version ""1.8.0_322""
                 OpenJDK Runtime Environment Corretto-8.322.06.1 (build 1.8.0_322-b06)
                 OpenJDK 64-Bit Server VM Corretto-8.322.06.1 (build 25.322-b06, mixed mode)
             ";

--- a/Tests/Runtime/Core/InstalledJavaVersionCheck/InstalledJavaVersionProviderTests.cs
+++ b/Tests/Runtime/Core/InstalledJavaVersionCheck/InstalledJavaVersionProviderTests.cs
@@ -62,7 +62,6 @@ namespace AmazonGameLiftPlugin.Core.Tests.InstalledJavaVersionCheck
             var response = GetCheckInstalledJavaVersionResponse(output, 8);
             Assert.IsTrue(response.Success, "Request was not successful");
             Assert.IsTrue(response.IsInstalled);
-
         }
 
         [Test]
@@ -77,7 +76,7 @@ namespace AmazonGameLiftPlugin.Core.Tests.InstalledJavaVersionCheck
         [Test]
         public void CheckInstalledJavaVersion_WithSecurityPatch()
         {
-            var output = "java version \"9.1.1.1\"";
+            var output = "java version \"1.09.1.1\"";
             var response = GetCheckInstalledJavaVersionResponse(output, 8);
             Assert.IsTrue(response.Success, "Request was not successful");
             Assert.IsTrue(response.IsInstalled);

--- a/Tests/Runtime/Core/InstalledJavaVersionCheck/InstalledJavaVersionProviderTests.cs
+++ b/Tests/Runtime/Core/InstalledJavaVersionCheck/InstalledJavaVersionProviderTests.cs
@@ -36,6 +36,35 @@ namespace AmazonGameLiftPlugin.Core.Tests.InstalledJavaVersionCheck
         }
 
         [Test]
+        public void CheckInstalledJavaVersion_WhenExpectedJavaVersionIsMultiline_IsSuccessFul()
+        {
+            string output = @"
+                Picked up JAVA_TOOL_OPTIONS: -Dlog4j2.formatMsgNoLookups=true
+                java version ""1.8.0_291""
+                OpenJDK Runtime Environment Corretto-8.322.06.1 (build 1.8.0_322-b06)
+                OpenJDK 64-Bit Server VM Corretto-8.322.06.1 (build 25.322-b06, mixed mode)
+            ";
+
+            var processWrapperMock = new Mock<IProcessWrapper>();
+            processWrapperMock.Setup(x => x.GetProcessOutput(
+                It.IsAny<ProcessStartInfo>())
+            ).Returns(output);
+
+            IInstalledJavaVersionProvider installedJavaVersionProvider =
+                InstalledJavaVersionProviderFactory.Create(processWrapperMock.Object);
+
+            CheckInstalledJavaVersionResponse response =
+                installedJavaVersionProvider.CheckInstalledJavaVersion(new CheckInstalledJavaVersionRequest
+                {
+                    ExpectedMinimumJavaMajorVersion = 8
+                });
+
+            processWrapperMock.Verify();
+            Assert.IsTrue(response.Success, "Request was not successful");
+            Assert.IsTrue(response.IsInstalled);
+        }
+
+        [Test]
         public void CheckInstalledJavaVersion_WhenExpectedJavaVersionIsNotInstalled_IsNotSuccessFul()
         {
             var processWrapperMock = new Mock<IProcessWrapper>();

--- a/Tests/Runtime/Core/InstalledJavaVersionCheck/InstalledJavaVersionProviderTests.cs
+++ b/Tests/Runtime/Core/InstalledJavaVersionCheck/InstalledJavaVersionProviderTests.cs
@@ -91,5 +91,13 @@ namespace AmazonGameLiftPlugin.Core.Tests.InstalledJavaVersionCheck
             Assert.IsTrue(response.Success, "Request was not successful");
             Assert.IsFalse(response.IsInstalled);
         }
+
+        [Test]
+        public void CheckInstalledJavaVersion_WhenJavaIsEmpty()
+        {
+            var response = GetCheckInstalledJavaVersionResponse("", 8);
+            Assert.IsTrue(response.Success, "Request was not successful");
+            Assert.IsFalse(response.IsInstalled);
+        }
     }
 }

--- a/Tests/Runtime/Core/InstalledJavaVersionCheck/InstalledJavaVersionProviderTests.cs
+++ b/Tests/Runtime/Core/InstalledJavaVersionCheck/InstalledJavaVersionProviderTests.cs
@@ -74,6 +74,19 @@ namespace AmazonGameLiftPlugin.Core.Tests.InstalledJavaVersionCheck
         }
 
         [Test]
+        public void CheckInstalledJavaVersion_WhenExpectedJavaVersionUsesShortFormatAndIsV1()
+        {
+            var output = "openjdk version \"1\"";
+            var response = GetCheckInstalledJavaVersionResponse(output, 8);
+            Assert.IsTrue(response.Success, "Request was not successful");
+            Assert.IsFalse(response.IsInstalled);
+
+            var response2 = GetCheckInstalledJavaVersionResponse(output, 1);
+            Assert.IsTrue(response2.Success, "Request was not successful");
+            Assert.IsTrue(response2.IsInstalled);
+        }
+
+        [Test]
         public void CheckInstalledJavaVersion_WithSecurityPatch()
         {
             var output = "java version \"1.09.1.1\"";


### PR DESCRIPTION
Sometimes the version is present on the second line. Ex: $ java -version
Picked up JAVA_TOOL_OPTIONS: -Dlog4j2.formatMsgNoLookups=true openjdk version "1.8.0_322"
OpenJDK Runtime Environment Corretto-8.322.06.1 (build 1.8.0_322-b06) OpenJDK 64-Bit Server VM Corretto-8.322.06.1 (build 25.322-b06, mixed mode)

The code needs to account for that case.

*Issue #, if available:*
[58](https://github.com/aws/amazon-gamelift-plugin-unity/issues/58)

*Description of changes:*
- Ensure we read the entire output of "java -version", not just the first line.
- Update RegExp to extract the "java version 1.8.??" portion for validation.
- Added new unit test to verify scenario above.

*Tested using the following code*
```
using AmazonGameLiftPlugin.Core.Shared.ProcessManagement;
using AmazonGameLiftPlugin.Core.Tests.InstalledJavaVersionCheck;

namespace AmazonGameLiftPlugin.Core.JavaCheck.Models {
  class Test {
    static public void Main(String[] args) {
      IProcessWrapper processWrapper = new ProcessWrapper();
      InstalledJavaVersionProvider provider = new InstalledJavaVersionProvider(processWrapper);
      CheckInstalledJavaVersionRequest request = new CheckInstalledJavaVersionRequest();
      request.ExpectedMinimumJavaMajorVersion = 8;
      Console.WriteLine("Min Java version:" + request.ExpectedMinimumJavaMajorVersion + " -> " + provider.CheckInstalledJavaVersion(request).IsInstalled);
      request.ExpectedMinimumJavaMajorVersion = 9;
      Console.WriteLine("Min Java version:" + request.ExpectedMinimumJavaMajorVersion + " -> " + provider.CheckInstalledJavaVersion(request).IsInstalled);

      InstalledJavaVersionProviderTests tests = new InstalledJavaVersionProviderTests();
      tests.CheckInstalledJavaVersion_WhenExpectedJavaVersionIsInstalled_IsSuccessFul();
      tests.CheckInstalledJavaVersion_WhenExpectedJavaVersionIsMultiline_IsSuccessFul();
      tests.CheckInstalledJavaVersion_WhenExpectedJavaVersionIsNotInstalled_IsNotSuccessFul();
      tests.CheckInstalledJavaVersion_WhenJavaIsNotInstalled_IsNotSuccessFul();
    }
  }
}

```
Output:
```
Min Java version:8 -> True
Min Java version:9 -> False
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
