### PR TITLE
Revert minimum Unity version to 2021.3; Fix local testing for MacOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 CHANGELOG
 
-# 1.3.1 (12/06/2023)
+# 1.3.1 (08/04/2023)
 
-- Update minimum required Unity version from 2021.3 to 2022.3
+- Add support for Unity version 2022.3
+- Fix local testing UI not able to run MacOS server executables built with "Dedicated Server" platform in Unity 2021 and newer.
 
 # 1.3.0 (04/20/2023)
 

--- a/Editor/LocalTest/LocalTest.cs
+++ b/Editor/LocalTest/LocalTest.cs
@@ -38,8 +38,7 @@ namespace AmazonGameLift.Editor
 
         public string GameLiftLocalPath { get; private set; }
 
-        public bool IsBuildExecutablePathFilled =>
-            OperatingSystemUtility.isMacOs() ? _coreApi.FolderExists(BuildExecutablePath) : _coreApi.FileExists(BuildExecutablePath);
+        public bool IsBuildExecutablePathFilled => _coreApi.FileExists(BuildExecutablePath);
 
         public bool isGameLiftLocalPortValid => GameLiftLocalPort > 0;
 

--- a/Runtime/Core/GameLiftLocalTesting/GameLiftProcess.cs
+++ b/Runtime/Core/GameLiftLocalTesting/GameLiftProcess.cs
@@ -189,7 +189,7 @@ namespace AmazonGameLiftPlugin.Core.GameLiftLocalTesting
                     // Starts a bash process to run an Apple script, which activates a new Terminal App window,
                     // and runs the game server executable in the Unity compiled .app file
                     string activateTerminalScript = $"tell application \\\"Terminal\\\" to activate";
-                    string setGameServerFilePath = $"set GameServerFilePathEnvVar to \\\"{request.FilePath}/Contents/MacOS/{request.ApplicationProductName}\\\"";
+                    string setGameServerFilePath = $"set GameServerFilePathEnvVar to \\\"{request.FilePath}\\\"";
                     string runGameServerScript = $"GameServerFilePathEnvVar";
                     string runGameServer = $"tell application \\\"Terminal\\\" to do script {runGameServerScript}";
                     string osaScript = $"osascript -e \'{activateTerminalScript}\' -e \'{setGameServerFilePath}\' -e \'{runGameServer}\'";

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Amazon GameLift Plugin for Unity",
   "author": "Amazon.com, Inc.",
   "version": "1.3.1",
-  "unity": "2022.3",
+  "unity": "2021.3",
   "description": "The Amazon GameLift Plugin for Unity contains libraries and native UI that makes it easier to access GameLift resources and integrate GameLift into your Unity game. You can use the GameLift Unity Plugin to access GameLift APIs and deploy AWS CloudFormation templates for common gaming scenarios.",
   "documentationUrl": "https://docs.aws.amazon.com/gamelift/latest/developerguide/unity-plug-in.html",
   "changelogUrl": "https://github.com/aws/amazon-gamelift-plugin-unity/blob/main/CHANGELOG.md",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In Unity 2021.3 and above, dedicated servers are no longer built as an .app file (i.e. a directory), but as a standalone executable. Due to the plugin checks if provided server executable path is a directory, Local UI greys out the Deploy&Run button. Also, the applescript runs testapp also needs to be updated to remove the assumption that the executable path is an .app directory.

This change fixes the above issue, see screenshot below. It also reverts minimum version to 2021.3 (there is no reason to bump up the minimum version since the app is still compatible with 2021.3):
![Screenshot 2023-08-01 at 3 21 45 PM](https://github.com/aws/amazon-gamelift-plugin-unity/assets/8877010/4105da4d-0ed2-4199-8f2c-bdd3c4c1f69f)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
