### PR TITLE
Add link icon to landing page link

### DIFF
--- a/Editor/Resources/EditorWindow/Pages/LandingPage.uxml
+++ b/Editor/Resources/EditorWindow/Pages/LandingPage.uxml
@@ -17,7 +17,10 @@
                     <ui:Image name="LandingPageNoAccountImage" class="card__icon icon--large"/>
                     <ui:Label name="LandingPageNoAccountCardText" class="card__text" text="I don&apos;t have an AWS account"/>
                 </ui:VisualElement>
-                <ui:Button class="button card__button button--large button--full-width" text="Create an AWS Account   \uf08e" name="CreateAccount"/>
+                <ui:Button class="button card__button button--large button--full-width" name="CreateAccount">
+                    <ui:Label name="LandingPageNoAccountCardButton" />
+                    <ui:Image name="ExternalLinkIcon" class="icon--small"/>
+                </ui:Button>
             </ui:VisualElement>
             <ui:VisualElement class="card">
                 <ui:VisualElement class="card__container">


### PR DESCRIPTION
Before:
![image](https://github.com/aws/amazon-gamelift-plugin-unity/assets/109524503/226f2230-2207-42ef-bfa0-bd41cfdb10a7)


After:

![image](https://github.com/aws/amazon-gamelift-plugin-unity/assets/109524503/83f0bdce-5f58-4b1a-91db-36c1f3b6eee5)


Add link icon to landing page link

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
