### PR TITLE
Fixed styling of link in card on profile page

### DIFF
--- a/Editor/Resources/EditorWindow/Pages/AwsUserProfilesPage.uxml
+++ b/Editor/Resources/EditorWindow/Pages/AwsUserProfilesPage.uxml
@@ -15,7 +15,7 @@
                 <ui:Image name="UserProfilePageAccountCardNoAccountIcon" class="card__icon card__icon--large"/>
                 <ui:Label name="UserProfilePageAccountCardNoAccountTitle" class="card__title" text="I don’t have an AWS account"/>
                 <ui:Label name="UserProfilePageAccountCardNoAccountDescription" text="[text about needing an AWS account and it can take a maximum of two sentences]"/>
-                <ui:VisualElement class="float-right">
+                <ui:VisualElement class="external-link">
                     <ui:Label name="UserProfilePageAccountCardNoAccountLink" text="Learn More"/>
                     <ui:Image name="ExternalLinkIcon" class="icon--small"/>
                 </ui:VisualElement>

--- a/Editor/Resources/EditorWindow/common.uss
+++ b/Editor/Resources/EditorWindow/common.uss
@@ -401,6 +401,10 @@ Image#ExternalLinkIcon {
     align-self: center;
 }
 
+.card .external-link {
+    align-self: center;
+}
+
 .card__title {
     font-size: var(--font-size-extralarge);
 }


### PR DESCRIPTION
Fixed styling of link in card on profile page

Before:
![image](https://github.com/aws/amazon-gamelift-plugin-unity/assets/109524503/95915400-843d-41b6-b537-9d62aacab674)


After: 
![image](https://github.com/aws/amazon-gamelift-plugin-unity/assets/109524503/9faee997-abf7-4515-876a-61fb7aa540d9)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
