### PR TITLE
Correctly enable anywhere input fields after bootstrapping

### DIFF
--- a/Editor/Window/ConnectToFleetInput.cs
+++ b/Editor/Window/ConnectToFleetInput.cs
@@ -47,7 +47,11 @@ namespace AmazonGameLift.Editor
             SetupPage();
             SetupStatusBox();
             LocalizeText();
-            _stateManager.OnUserProfileUpdated += () => UpdateFleetMenu();
+            _stateManager.OnUserProfileUpdated += async () =>
+            {
+                await UpdateFleetMenu();
+                UpdateGUI();
+            };
 
             UpdateGUI();
         }

--- a/Editor/Window/RegisterComputeInput.cs
+++ b/Editor/Window/RegisterComputeInput.cs
@@ -135,12 +135,6 @@ namespace AmazonGameLift.Editor
             UpdateGUI();
         }
 
-        private void SetInputsReadonly(bool value)
-        {
-            _computeNameInput.isReadOnly = value;
-            _ipInputs.ForEach(input => input.isReadOnly = value);
-        }
-
         private void UpdateComputeTextFields(TextField computeTextField, IEnumerable<TextField> ipTextField)
         {
             var computeTextNameValid = computeTextField.value.Length >= 1;
@@ -188,7 +182,6 @@ namespace AmazonGameLift.Editor
 
         protected sealed override void UpdateGUI()
         {
-            SetInputsReadonly(_computeState == ComputeStatus.Registered);
             var elements = GetVisibleItemsByState();
             foreach (var element in GetComputeVisualElements())
             {


### PR DESCRIPTION
Correctly enable anywhere input fields after bootstrapping

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
