### PR TITLE
Default Text Compute Bug Fix

### DIFF
--- a/Editor/Window/RegisterComputeInput.cs
+++ b/Editor/Window/RegisterComputeInput.cs
@@ -86,12 +86,6 @@ namespace AmazonGameLift.Editor
         {
             if (_computeState is ComputeStatus.NotRegistered or ComputeStatus.Registering)
             {
-                Debug.Log(_computeName);
-                Debug.Log(_stateManager);
-                Debug.Log(_stateManager.AnywhereFleetId);
-                Debug.Log(_location);
-                Debug.Log(_ipAddress);
-                Debug.Log(_computeManager);
                 var previousComputeName = _stateManager.ComputeName;
                 var registerResponse = await _computeManager.RegisterFleetCompute(_computeName,
                     _stateManager.AnywhereFleetId, _location, _ipAddress);

--- a/Editor/Window/RegisterComputeInput.cs
+++ b/Editor/Window/RegisterComputeInput.cs
@@ -50,8 +50,8 @@ namespace AmazonGameLift.Editor
                             !string.IsNullOrWhiteSpace(_stateManager.IpAddress)
                 ? ComputeStatus.Registered
                 : ComputeStatus.NotRegistered;
-            _computeName = _stateManager.ComputeName ?? _computeName;
-            _ipAddress = _stateManager.IpAddress ?? _ipAddress;
+            _computeName = !string.IsNullOrWhiteSpace(_stateManager.ComputeName) ? _stateManager.ComputeName:  _computeName;
+            _ipAddress = !string.IsNullOrWhiteSpace(_stateManager.IpAddress) ? _stateManager.IpAddress:  _ipAddress;
             _stateManager.OnUserProfileUpdated += UpdateGUI;
 
             RegisterCallbacks();
@@ -86,6 +86,12 @@ namespace AmazonGameLift.Editor
         {
             if (_computeState is ComputeStatus.NotRegistered or ComputeStatus.Registering)
             {
+                Debug.Log(_computeName);
+                Debug.Log(_stateManager);
+                Debug.Log(_stateManager.AnywhereFleetId);
+                Debug.Log(_location);
+                Debug.Log(_ipAddress);
+                Debug.Log(_computeManager);
                 var previousComputeName = _stateManager.ComputeName;
                 var registerResponse = await _computeManager.RegisterFleetCompute(_computeName,
                     _stateManager.AnywhereFleetId, _location, _ipAddress);


### PR DESCRIPTION
#Bug Description*
Registering a new compute with default text "ComputerName-ProfileName" throws an error
Null reference on line 90 in RegisterComputeInput when installing the plugin for the first time, selecting account, making fleet, then clicking register compute. 

*Description of changes:*
Small change to use default values if this is plugins first install and they don't change default values.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
