### PR TITLE
Added missing setting

### DIFF
--- a/Editor/CoreAPI/StateManager.cs
+++ b/Editor/CoreAPI/StateManager.cs
@@ -49,6 +49,7 @@ namespace AmazonGameLift.Editor
             {
                 _selectedProfile.BucketName = value;
                 SaveProfiles();
+                CoreApi.PutSetting(SettingsKeys.CurrentBucketName, value);
             }
         }
 


### PR DESCRIPTION
Managed EC2 deploys were not working because the plugin failed to set `CurrentBucketName` in the settings file. This is a dependency in the deployers, specifically loaded into DeploymentRequestFactory and is very awkward to get StateManager to, so I have stuck with the existing implementation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
