### PR TITLE
Set `CurrentBucketName` on profile load

### DIFF
--- a/Editor/CoreAPI/StateManager.cs
+++ b/Editor/CoreAPI/StateManager.cs
@@ -240,6 +240,7 @@ namespace AmazonGameLift.Editor
             CoreApi.PutSetting(SettingsKeys.CurrentProfileName, profileName);
             var credentials = CoreApi.RetrieveAwsCredentials(profileName);
             Region = credentials.Region;
+            BucketName = _selectedProfile.BucketName;
             GameLiftWrapper = AmazonGameLiftWrapperFactory.Get(ProfileName);
             FleetManager = new GameLiftFleetManager(GameLiftWrapper);
             ComputeManager = new GameLiftComputeManager(GameLiftWrapper);


### PR DESCRIPTION
This is a fix for the `CurrentBucketName` value not being set when a profile is set. This is a fix until the `CurrentBucketName` is refactored away

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
