### PR TITLE
Correctly switch deployment scenarios and load them from profile

### DIFF
--- a/Editor/Window/DeploymentScenariosInput.cs
+++ b/Editor/Window/DeploymentScenariosInput.cs
@@ -20,8 +20,9 @@ namespace AmazonGameLift.Editor
         private readonly Button _showMoreScenariosButton;
 
         public Action<DeploymentScenarios> OnValueChanged;
+        private Dictionary<DeploymentScenarios , RadioButton> _radioButtons = new Dictionary<DeploymentScenarios, RadioButton>();
 
-        public DeploymentScenariosInput(VisualElement container, DeploymentScenarios deploymentScenario, bool enabled)
+        public DeploymentScenariosInput(VisualElement container, DeploymentScenarios deploymentScenario, bool enabled, StateManager stateManager)
         {
             var uxml = Resources.Load<VisualTreeAsset>("EditorWindow/Components/DeploymentScenarios");
             container.Add(uxml.Instantiate());
@@ -44,6 +45,15 @@ namespace AmazonGameLift.Editor
                 _isExpanded = true;
                 UpdateGUI();
             });
+            stateManager.OnUserProfileUpdated += () =>
+            {
+                SetValue(stateManager.DeploymentScenario);
+                if (stateManager.DeploymentScenario != DeploymentScenarios.SingleRegion)
+                {
+                    _isExpanded = true;
+                }
+                UpdateGUI();
+            };
             
             _container.Q<VisualElement>("ManagedEC2ScenarioSingleFleetLinkParent")
                 .RegisterCallback<ClickEvent>(_ => Application.OpenURL(Urls.ManagedEc2FleetLearnMore));
@@ -62,10 +72,16 @@ namespace AmazonGameLift.Editor
             _container.SetEnabled(_enabled);
         }
 
+        private void SetValue(DeploymentScenarios deploymentScenario)
+        {
+            _radioButtons[deploymentScenario].value = true;
+        }
+
         private void SetupRadioButton(string elementName, DeploymentScenarios deploymentScenario)
         {
             var radio = _container.Q<RadioButton>(elementName);
             if (radio == default) return;
+            _radioButtons.Add(deploymentScenario, radio);
             radio.value = _deploymentScenarios == deploymentScenario;
             radio.RegisterValueChangedCallback(v =>
             {

--- a/Editor/Window/DeploymentScenariosInput.cs
+++ b/Editor/Window/DeploymentScenariosInput.cs
@@ -45,15 +45,7 @@ namespace AmazonGameLift.Editor
                 _isExpanded = true;
                 UpdateGUI();
             });
-            stateManager.OnUserProfileUpdated += () =>
-            {
-                SetValue(stateManager.DeploymentScenario);
-                if (stateManager.DeploymentScenario != DeploymentScenarios.SingleRegion)
-                {
-                    _isExpanded = true;
-                }
-                UpdateGUI();
-            };
+            stateManager.OnUserProfileUpdated += UpdateGUI;
             
             _container.Q<VisualElement>("ManagedEC2ScenarioSingleFleetLinkParent")
                 .RegisterCallback<ClickEvent>(_ => Application.OpenURL(Urls.ManagedEc2FleetLearnMore));
@@ -70,11 +62,6 @@ namespace AmazonGameLift.Editor
         {
             _enabled = value;
             _container.SetEnabled(_enabled);
-        }
-
-        private void SetValue(DeploymentScenarios deploymentScenario)
-        {
-            _radioButtons[deploymentScenario].value = true;
         }
 
         private void SetupRadioButton(string elementName, DeploymentScenarios deploymentScenario)
@@ -113,6 +100,12 @@ namespace AmazonGameLift.Editor
 
         protected sealed override void UpdateGUI()
         {
+            _radioButtons[deploymentScenario].value = true;
+            if (stateManager.DeploymentScenario != DeploymentScenarios.SingleRegion)
+            {
+                _isExpanded = true;
+            }
+
             var elements = GetVisibleItemsByState();
             foreach (var element in GetExtraScenarioElements())
             {

--- a/Editor/Window/DeploymentScenariosInput.cs
+++ b/Editor/Window/DeploymentScenariosInput.cs
@@ -19,6 +19,8 @@ namespace AmazonGameLift.Editor
         private readonly VisualElement _flexMatchRadioGroup;
         private readonly Button _showMoreScenariosButton;
 
+        private readonly StateManager _stateManager;
+
         public Action<DeploymentScenarios> OnValueChanged;
         private Dictionary<DeploymentScenarios , RadioButton> _radioButtons = new Dictionary<DeploymentScenarios, RadioButton>();
 
@@ -31,6 +33,8 @@ namespace AmazonGameLift.Editor
             _isExpanded = deploymentScenario != DeploymentScenarios.SingleRegion;
             _deploymentScenarios = deploymentScenario;
             _enabled = enabled;
+            _stateManager = stateManager;
+
             _container.SetEnabled(_enabled);
 
             _spotFleetRadioGroup = container.Q("ManagedEC2ScenarioSpotFleet");
@@ -39,12 +43,14 @@ namespace AmazonGameLift.Editor
             SetupRadioButton("ManagedEC2ScenarioSingleFleetRadio", DeploymentScenarios.SingleRegion);
             SetupRadioButton("ManagedEC2ScenarioSpotFleetRadio", DeploymentScenarios.SpotFleet);
             SetupRadioButton("ManagedEC2ScenarioFlexMatchRadio", DeploymentScenarios.FlexMatch);
+
             _showMoreScenariosButton = container.Q<Button>("ManagedEC2ScenarioShowMoreButton");
             _showMoreScenariosButton.RegisterCallback<ClickEvent>(e =>
             {
                 _isExpanded = true;
                 UpdateGUI();
             });
+            
             stateManager.OnUserProfileUpdated += UpdateGUI;
             
             _container.Q<VisualElement>("ManagedEC2ScenarioSingleFleetLinkParent")
@@ -100,8 +106,9 @@ namespace AmazonGameLift.Editor
 
         protected sealed override void UpdateGUI()
         {
+            var deploymentScenario = _stateManager.DeploymentScenario;
             _radioButtons[deploymentScenario].value = true;
-            if (stateManager.DeploymentScenario != DeploymentScenarios.SingleRegion)
+            if (deploymentScenario != DeploymentScenarios.SingleRegion)
             {
                 _isExpanded = true;
             }

--- a/Editor/Window/ManagedEC2Page.cs
+++ b/Editor/Window/ManagedEC2Page.cs
@@ -48,8 +48,8 @@ namespace AmazonGameLift.Editor
             var scenarioContainer = container.Q("ManagedEC2ScenarioTitle");
             _deploymentScenariosInput =
                 new DeploymentScenariosInput(scenarioContainer, _deploymentSettings.Scenario,
-                    _stateManager.IsBootstrapped);
-            _deploymentScenariosInput.OnValueChanged += value => { Debug.Log($"Fleet type changed to {value}"); };
+                    _stateManager.IsBootstrapped, stateManager);
+            _deploymentScenariosInput.OnValueChanged += value => { _deploymentSettings.Scenario = value; };
             _statusIndicator = _container.Q<StatusIndicator>();
             var parametersContainer = container.Q<Foldout>("ManagedEC2ParametersTitle");
             _fleetParamsInput = new FleetParametersInput(parametersContainer, parameters);


### PR DESCRIPTION
Added radio buttons to a dictionary so we can set the value when profile changes.
When scenario input emits a change event, set the value in `deploymentSettings`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
