### PR TITLE
Adding default region `us-east-1` to credentials response

### DIFF
--- a/Runtime/Core/CredentialManagement/CredentialsStore.cs
+++ b/Runtime/Core/CredentialManagement/CredentialsStore.cs
@@ -79,7 +79,7 @@ namespace AmazonGameLiftPlugin.Core.CredentialManagement
                 {
                     AccessKey = credentials.AccessKey,
                     SecretKey = credentials.SecretKey,
-                    Region = profile.Region.SystemName,
+                    Region = profile.Region?.SystemName ?? RegionEndpoint.USEast1.SystemName,
                 });
             }
 

--- a/Runtime/Core/CredentialManagement/CredentialsStore.cs
+++ b/Runtime/Core/CredentialManagement/CredentialsStore.cs
@@ -79,6 +79,7 @@ namespace AmazonGameLiftPlugin.Core.CredentialManagement
                 {
                     AccessKey = credentials.AccessKey,
                     SecretKey = credentials.SecretKey,
+                    // https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/setup-credentials.html#setup-credentials-setting-region
                     Region = profile.Region?.SystemName ?? RegionEndpoint.USEast1.SystemName,
                 });
             }


### PR DESCRIPTION
Adding default region `us-east-1` to credentials response if credential profile has none set

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
