### PR TITLE
Removing log button from anywhere page

### DIFF
--- a/Editor/Window/ConnectToFleetInput.cs
+++ b/Editor/Window/ConnectToFleetInput.cs
@@ -59,15 +59,13 @@ namespace AmazonGameLift.Editor
         {
             if (_fleetManager != null && _fleetState is FleetStatus.NotCreated or FleetStatus.Creating)
             {
-                var url = string.Format(Urls.AwsGameLiftLogs, _stateManager.Region);
                 _connectToAnywhereStatusBox.Close();
                 
                 var customLocationResponse = await _fleetManager.CreateCustomLocationIfNotExists();
                 if (!customLocationResponse.Success)
                 {
                     _connectToAnywhereStatusBox.Show(StatusBox.StatusBoxType.Error,
-                        Strings.AnywherePageStatusBoxDefaultErrorText, customLocationResponse.ErrorMessage, url,
-                        Strings.ViewLogsStatusBoxUrlTextButton);
+                        Strings.AnywherePageStatusBoxDefaultErrorText, customLocationResponse.ErrorMessage);
                     return;
                 }
                 
@@ -85,8 +83,7 @@ namespace AmazonGameLift.Editor
                 else
                 {
                     _connectToAnywhereStatusBox.Show(StatusBox.StatusBoxType.Error,
-                        Strings.AnywherePageStatusBoxDefaultErrorText, createFleetResponse.ErrorMessage, url,
-                        Strings.ViewLogsStatusBoxUrlTextButton);
+                        Strings.AnywherePageStatusBoxDefaultErrorText, createFleetResponse.ErrorMessage);
                 }
             }
 

--- a/Editor/Window/RegisterComputeInput.cs
+++ b/Editor/Window/RegisterComputeInput.cs
@@ -108,12 +108,9 @@ namespace AmazonGameLift.Editor
                 }
                 else
                 {
-                    var url = string.Format(Urls.AwsGameLiftLogs, _stateManager.Region);
                     _registerComputeStatusBox.Show(StatusBox.StatusBoxType.Error,
-                        Strings.AnywherePageStatusBoxDefaultErrorText, 
-                        registerResponse.ErrorMessage, 
-                        url,
-                        Strings.ViewLogsStatusBoxUrlTextButton);
+                        Strings.AnywherePageStatusBoxDefaultErrorText,
+                        registerResponse.ErrorMessage);
                 }
             }
             


### PR DESCRIPTION
As log button is meant to take us to unity logs, this button isn't needed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
