### PR TITLE
Adding ability to remember tab from last visit;

### DIFF
--- a/Editor/CoreAPI/SettingsKeys.cs
+++ b/Editor/CoreAPI/SettingsKeys.cs
@@ -9,5 +9,6 @@ namespace AmazonGameLift.Editor
         CurrentProfileName,
         CurrentRegion,
         UserProfiles,
+        LastOpenTab
     }
 }

--- a/Editor/CoreAPI/StateManager.cs
+++ b/Editor/CoreAPI/StateManager.cs
@@ -26,6 +26,15 @@ namespace AmazonGameLift.Editor
         private readonly IDeserializer _deserializer = new DeserializerBuilder().Build();
 
         public UserProfile SelectedProfile => _selectedProfile;
+        
+        public string LastOpenTab
+        {
+            get => CoreApi.GetSetting(SettingsKeys.LastOpenTab).Value;
+            set
+            {
+                CoreApi.PutSetting(SettingsKeys.LastOpenTab, value);
+            }
+        }
 
         #region Profile Settings
 

--- a/Editor/Window/GameLiftPlugin.cs
+++ b/Editor/Window/GameLiftPlugin.cs
@@ -56,11 +56,7 @@ namespace AmazonGameLift.Editor
             _tabButtons = _root.Query<Button>(className: TabButtonClassName).ToList();
             _tabContent = _root.Query(className: TabContentClassName).ToList();
 
-            _tabButtons.ForEach(button => button.RegisterCallback<ClickEvent>(_ =>
-            {
-                OpenTab(button.name);
-                StateManager.LastOpenTab = button.name;
-            }));
+            _tabButtons.ForEach(button => button.RegisterCallback<ClickEvent>(_ => { OpenTab(button.name); }));
 
             if (string.IsNullOrWhiteSpace(StateManager.LastOpenTab))
             {
@@ -95,8 +91,9 @@ namespace AmazonGameLift.Editor
             return container;
         }
 
-      private void OpenTab(string tabName)
+        private void OpenTab(string tabName)
         {
+            StateManager.LastOpenTab = button.name;
             _tabContent.ForEach(page =>
             {
                 if (page.name == $"{tabName}Content")

--- a/Editor/Window/GameLiftPlugin.cs
+++ b/Editor/Window/GameLiftPlugin.cs
@@ -56,9 +56,20 @@ namespace AmazonGameLift.Editor
             _tabButtons = _root.Query<Button>(className: TabButtonClassName).ToList();
             _tabContent = _root.Query(className: TabContentClassName).ToList();
 
-            _tabButtons.ForEach(button => button.RegisterCallback<ClickEvent>(_ => { OpenTab(button.name); }));
-            
-            OpenTab(Pages.Landing);
+            _tabButtons.ForEach(button => button.RegisterCallback<ClickEvent>(_ =>
+            {
+                OpenTab(button.name);
+                StateManager.LastOpenTab = button.name;
+            }));
+
+            if (string.IsNullOrWhiteSpace(StateManager.LastOpenTab))
+            {
+                OpenTab(Pages.Landing);
+            }
+            else
+            {
+                OpenTab(StateManager.LastOpenTab);
+            }
         }
 
         private void LocalizeText()


### PR DESCRIPTION
For general usability and for the launch server button, I needed to add a setting to the file so that we could distinguish what the previous page the user visited is. This will help with restarting the unity client and plugin menu, along with any forced refreshes like launching the unity play mode. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
