### PR TITLE
Joined name and id in fleet dropdown

### DIFF
--- a/Editor/Window/ConnectToFleetInput.cs
+++ b/Editor/Window/ConnectToFleetInput.cs
@@ -173,7 +173,7 @@ namespace AmazonGameLift.Editor
                     $"{_stateManager.AnywhereFleetName} | {_stateManager.AnywhereFleetId}";
                 _fleetIdText.text = _stateManager.AnywhereFleetId;
 
-                var fleet = _fleetAttributes.FirstOrDefault(fleet => fleet.Name == _stateManager.AnywhereFleetName);
+                var fleet = _fleetAttributes.FirstOrDefault(fleet => fleet.FleetId == _stateManager.AnywhereFleetId);
                 if (fleet != null)
                 {
                     var textProvider = new TextProvider();

--- a/Editor/Window/ConnectToFleetInput.cs
+++ b/Editor/Window/ConnectToFleetInput.cs
@@ -61,7 +61,7 @@ namespace AmazonGameLift.Editor
             {
                 var url = string.Format(Urls.AwsGameLiftLogs, _stateManager.Region);
                 _connectToAnywhereStatusBox.Close();
-                
+
                 var customLocationResponse = await _fleetManager.CreateCustomLocationIfNotExists();
                 if (!customLocationResponse.Success)
                 {
@@ -70,7 +70,7 @@ namespace AmazonGameLift.Editor
                         Strings.ViewLogsStatusBoxUrlTextButton);
                     return;
                 }
-                
+
                 var createFleetResponse = await _fleetManager.CreateFleet(fleetName, customLocationResponse.Location)!;
                 if (createFleetResponse.Success)
                 {
@@ -114,9 +114,13 @@ namespace AmazonGameLift.Editor
             UpdateGUI();
         }
 
-        private async void OnSelectFleetDropdown(string fleetName)
+        private async void OnSelectFleetDropdown(string fleetSelection)
         {
-            var currentFleet = _fleetAttributes.FirstOrDefault(fleet => fleet.Name == fleetName);
+            var items = fleetSelection.Split(" | ");
+            var fleetName = items[0];
+            var fleetId = items[1];
+            var currentFleet =
+                _fleetAttributes.FirstOrDefault(fleet => fleet.Name == fleetName && fleet.FleetId == fleetId);
             if (currentFleet != null)
             {
                 var fleetLocationResponse = await _fleetManager.FindFirstFleetLocation(currentFleet.FleetId);
@@ -163,8 +167,10 @@ namespace AmazonGameLift.Editor
                     _fleetAttributes = new List<FleetAttributes>();
                 }
 
-                _fleetNameDropdownContainer.choices = _fleetAttributes.Select(fleet => fleet.Name).ToList();
-                _fleetNameDropdownContainer.value = _stateManager.AnywhereFleetName;
+                _fleetNameDropdownContainer.choices =
+                    _fleetAttributes.Select(fleet => $"{fleet.Name} | {fleet.FleetId}").ToList();
+                _fleetNameDropdownContainer.value =
+                    $"{_stateManager.AnywhereFleetName} | {_stateManager.AnywhereFleetId}";
                 _fleetIdText.text = _stateManager.AnywhereFleetId;
 
                 var fleet = _fleetAttributes.FirstOrDefault(fleet => fleet.Name == _stateManager.AnywhereFleetName);
@@ -184,7 +190,7 @@ namespace AmazonGameLift.Editor
                 }
             }
         }
-        
+
         private void SetFleetState()
         {
             if (_fleetAttributes.Count == 0)
@@ -193,7 +199,7 @@ namespace AmazonGameLift.Editor
             }
             else
             {
-                var fleet = _fleetAttributes.FirstOrDefault(fleet => fleet.Name == _stateManager.AnywhereFleetName);
+                var fleet = _fleetAttributes.FirstOrDefault(fleet => fleet.FleetId == _stateManager.AnywhereFleetId);
 
                 _fleetState = fleet == null ? FleetStatus.Selecting : FleetStatus.Selected;
             }


### PR DESCRIPTION
Joining the name and id of fleets in the drodown to distinguish them from each other. 

![image](https://github.com/aws/amazon-gamelift-plugin-unity/assets/109524503/a3aa76bc-37e5-4a09-b3c6-8cc9f439d241)

It's not the ideal solution but Unity doesnt allow access to mapping values to choices or supplying custom controls for the dropdown items

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
