### PR TITLE
Fix header for Connect to Anywhere foldout

### DIFF
--- a/Editor/TextProvider.cs
+++ b/Editor/TextProvider.cs
@@ -243,7 +243,7 @@ namespace AmazonGameLift.Editor
             { Strings.AnywherePageCreateFleetNameHint, "Fleet Name must have 1–1024 characters. Valid characters are A-Z, a-z, 0-9, _ and - (hyphen)"},
             { Strings.AnywherePageCreateFleetButton, "Create New Anywhere Fleet"},
             { Strings.AnywherePageCreateFleetCancelButton, "Cancel"},
-            { Strings.AnywherePageConnectFleetTitle, "Integrate Amazon GameLift With Your Game Project"},
+            { Strings.AnywherePageConnectFleetTitle, "Connect to an Anywhere Fleet"},
             { Strings.AnywherePageCreateFleetNameLabel, "Fleet Name"},
             { Strings.AnywherePageConnectFleetNameLabel, "Fleet Name"},
             { Strings.AnywherePageConnectFleetIDLabel, "Fleet ID"},


### PR DESCRIPTION
During UAT, we found the Anywhere tab had duplicate headers. The connect to anywhere foldout had the wrong header, so I've quickly updated it here.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<img width="931" alt="update_anywhere_connect_header" src="https://github.com/aws/amazon-gamelift-plugin-unity/assets/89040953/ec018857-f939-4124-9120-4bae4849e1dc">