### PR TITLE
Fixes to RegisterComputeInput; Will use correct compute name; make fi…

### DIFF
--- a/Editor/Resources/EditorWindow/common.uss
+++ b/Editor/Resources/EditorWindow/common.uss
@@ -349,7 +349,6 @@ Image#ExternalLinkIcon {
     padding: 0;
     border-width: 0;
     background-color: rgba(0, 0, 0, 0);
-    flex-grow: 0;
 }
 
 .input-hint {

--- a/Editor/Window/RegisterComputeInput.cs
+++ b/Editor/Window/RegisterComputeInput.cs
@@ -165,6 +165,8 @@ namespace AmazonGameLift.Editor
                 _computeState = ComputeStatus.Registered;
             }
 
+            _computeNameInput.value = _stateManager.ComputeName;
+
             UpdateGUI();
         }
 
@@ -220,6 +222,26 @@ namespace AmazonGameLift.Editor
             _registerComputeStatusBox = _container.Q<StatusBox>("AnywherePageComputeStatusBox");
         }
 
+        private void CheckReadOnly()
+        {
+            if (_computeState == ComputeStatus.Registered)
+            {
+                _computeNameInput.isReadOnly = true;
+                foreach (var ipBox in _ipInputs)
+                {
+                    ipBox.isReadOnly = true;
+                }
+            }
+            else
+            {
+                _computeNameInput.isReadOnly = false;
+                foreach (var ipBox in _ipInputs)
+                {
+                    ipBox.isReadOnly = false;
+                }
+            }
+        }
+
         protected sealed override void UpdateGUI()
         {
             var elements = GetVisibleItemsByState();
@@ -244,6 +266,8 @@ namespace AmazonGameLift.Editor
                 _statusIndicator.Set(State.Success,
                     textProvider.Get(Strings.AnywherePageComputeStatusRegistered));
             }
+
+            CheckReadOnly();
         }
 
         private void LocalizeText()


### PR DESCRIPTION
> The Compute foldout allows the user to edit the compute name and ip address fields when the compute is registered. This should only be an option before registering and when registering a new compute.

Now will set fields to readonly if they are in the registered state. 

Also fixed a bug with canceling when changing the name. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
