### PR TITLE
Added ability to hide the launch client foldout until it is ready;

### DIFF
--- a/Editor/Window/AnywherePage.cs
+++ b/Editor/Window/AnywherePage.cs
@@ -13,6 +13,11 @@ namespace AmazonGameLift.Editor
         private readonly VisualElement _container;
         private readonly StateManager _stateManager;
         private StatusBox _statusBox;
+        private readonly ConnectToFleetInput _fleetInput;
+        private readonly RegisterComputeInput _computeInput;
+        private Foldout _launchClientFoldout;
+        
+        private const string InactiveFoldoutElementName = "hidden";
 
         public AnywherePage(VisualElement container, StateManager stateManager)
         {
@@ -28,14 +33,15 @@ namespace AmazonGameLift.Editor
                 .RegisterCallback<ClickEvent>(_ => Application.OpenURL(Urls.AnywherePageServerSetupDocumentation));
             container.Q<VisualElement>("AnywherePageIntegrateClientLinkParent")
                 .RegisterCallback<ClickEvent>(_ => Application.OpenURL(Urls.AnywherePageClientSetupDocumentation));
+            _launchClientFoldout = container.Q<Foldout>("AnywherePageLaunchTitle");
             SetupStatusBoxes();
 
             _stateManager.OnUserProfileUpdated += UpdateGui;
 
             var fleetInputContainer = uxml.Q("AnywherePageConnectFleetTitle");
-            var fleetInput = new ConnectToFleetInput(fleetInputContainer, stateManager);
+            _fleetInput = new ConnectToFleetInput(fleetInputContainer, stateManager);
             var computeInputContainer = uxml.Q("AnywherePageComputeTitle");
-            var computeInput =
+            _computeInput =
                 new RegisterComputeInput(computeInputContainer, stateManager);
             var launchButton = uxml.Q<Button>("AnywherePageLaunchServerButton");
             launchButton.RegisterCallback<ClickEvent>(_ =>
@@ -54,6 +60,8 @@ namespace AmazonGameLift.Editor
 
         private void UpdateGui()
         {
+            _launchClientFoldout.AddToClassList(InactiveFoldoutElementName);
+            
             if (!_stateManager.IsBootstrapped)
             {
                 _statusBox.Show(StatusBox.StatusBoxType.Warning, Strings.AnywherePageStatusBoxNotBootstrappedWarning);
@@ -61,6 +69,11 @@ namespace AmazonGameLift.Editor
             else
             {
                 _statusBox.Close();
+                if (_fleetInput.FleetState == ConnectToFleetInput.FleetStatus.Selected &&
+                    _computeInput.ComputeState == RegisterComputeInput.ComputeStatus.Registered)
+                {
+                    _launchClientFoldout.RemoveFromClassList(InactiveFoldoutElementName);
+                }
             }
         }
 

--- a/Editor/Window/ConnectToFleetInput.cs
+++ b/Editor/Window/ConnectToFleetInput.cs
@@ -27,7 +27,7 @@ namespace AmazonGameLift.Editor
         private readonly VisualElement _container;
         private Button _cancelButton;
 
-        private FleetStatus _fleetState;
+        public FleetStatus FleetState { get; private set; }
         private List<FleetAttributes> _fleetAttributes = new List<FleetAttributes>();
         private StatusBox _connectToAnywhereStatusBox;
 
@@ -38,7 +38,7 @@ namespace AmazonGameLift.Editor
             _container = container;
 
             _stateManager = stateManager;
-            _fleetState = FleetStatus.NotCreated;
+            FleetState = FleetStatus.NotCreated;
 
             AssignUiElements(container);
             RegisterCallBacks(container);
@@ -57,7 +57,7 @@ namespace AmazonGameLift.Editor
 
         private async Task OnAnywhereConnectClicked(string fleetName)
         {
-            if (_fleetManager != null && _fleetState is FleetStatus.NotCreated or FleetStatus.Creating)
+            if (_fleetManager != null && FleetState is FleetStatus.NotCreated or FleetStatus.Creating)
             {
                 _connectToAnywhereStatusBox.Close();
 
@@ -78,7 +78,7 @@ namespace AmazonGameLift.Editor
 
                     await UpdateFleetMenu();
                     _fleetNameDropdownContainer.value = fleetName;
-                    _fleetState = FleetStatus.Selected;
+                    FleetState = FleetStatus.Selected;
                 }
                 else
                 {
@@ -92,10 +92,10 @@ namespace AmazonGameLift.Editor
 
         private async Task OnCreateNewFleetClicked()
         {
-            if (_fleetState is FleetStatus.Selected or FleetStatus.Selecting)
+            if (FleetState is FleetStatus.Selected or FleetStatus.Selecting)
             {
                 await UpdateFleetMenu();
-                _fleetState = FleetStatus.Creating;
+                FleetState = FleetStatus.Creating;
             }
 
             UpdateGUI();
@@ -103,9 +103,9 @@ namespace AmazonGameLift.Editor
 
         private void OnCancelButtonClicked()
         {
-            if (_fleetState is FleetStatus.Creating)
+            if (FleetState is FleetStatus.Creating)
             {
-                _fleetState = FleetStatus.Selected;
+                FleetState = FleetStatus.Selected;
             }
 
             UpdateGUI();
@@ -125,7 +125,7 @@ namespace AmazonGameLift.Editor
                 _stateManager.AnywhereFleetName = currentFleet.Name;
                 _stateManager.AnywhereFleetId = currentFleet.FleetId;
                 _stateManager.AnywhereFleetLocation = fleetLocationResponse.Location;
-                _fleetState = FleetStatus.Selected;
+                FleetState = FleetStatus.Selected;
             }
 
             UpdateGUI();
@@ -192,13 +192,13 @@ namespace AmazonGameLift.Editor
         {
             if (_fleetAttributes.Count == 0)
             {
-                _fleetState = FleetStatus.NotCreated;
+                FleetState = FleetStatus.NotCreated;
             }
             else
             {
                 var fleet = _fleetAttributes.FirstOrDefault(fleet => fleet.FleetId == _stateManager.AnywhereFleetId);
 
-                _fleetState = fleet == null ? FleetStatus.Selecting : FleetStatus.Selected;
+                FleetState = fleet == null ? FleetStatus.Selecting : FleetStatus.Selected;
             }
         }
 
@@ -222,7 +222,7 @@ namespace AmazonGameLift.Editor
 
         private List<VisualElement> GetVisibleItemsByState()
         {
-            return _fleetState switch
+            return FleetState switch
             {
                 FleetStatus.NotCreated => new List<VisualElement>() { _fleetNameInput, _fleetCreateContainer },
                 FleetStatus.Creating => new List<VisualElement>()

--- a/Editor/Window/RegisterComputeInput.cs
+++ b/Editor/Window/RegisterComputeInput.cs
@@ -11,7 +11,7 @@ namespace AmazonGameLift.Editor
 {
     public class RegisterComputeInput : StatefulInput
     {
-        private ComputeStatus _computeState;
+        public ComputeStatus ComputeState { get; private set; }
 
         private readonly List<TextField> _ipInputs;
         private readonly TextField _computeNameInput;
@@ -45,7 +45,7 @@ namespace AmazonGameLift.Editor
             _statusIndicator = container.Q<StatusIndicator>();
             LocalizeText();
 
-            _computeState = !string.IsNullOrWhiteSpace(_stateManager.ComputeName) &&
+            ComputeState = !string.IsNullOrWhiteSpace(_stateManager.ComputeName) &&
                             !string.IsNullOrWhiteSpace(_stateManager.IpAddress)
                 ? ComputeStatus.Registered
                 : ComputeStatus.NotRegistered;
@@ -82,7 +82,7 @@ namespace AmazonGameLift.Editor
 
         private async void OnRegisterComputeButtonClicked()
         {
-            if (_computeState is ComputeStatus.NotRegistered or ComputeStatus.Registering)
+            if (ComputeState is ComputeStatus.NotRegistered or ComputeStatus.Registering)
             {
                 var previousComputeName = _stateManager.ComputeName;
                 var registerResponse = await _stateManager.ComputeManager.RegisterFleetCompute(_computeName,
@@ -92,7 +92,7 @@ namespace AmazonGameLift.Editor
                     _stateManager.ComputeName = registerResponse.ComputeName;
                     _stateManager.IpAddress = registerResponse.IpAddress;
                     _stateManager.WebSocketUrl = registerResponse.WebSocketUrl;
-                    _computeState = ComputeStatus.Registered;
+                    ComputeState = ComputeStatus.Registered;
 
                     if (!string.IsNullOrWhiteSpace(previousComputeName))
                     {
@@ -129,7 +129,7 @@ namespace AmazonGameLift.Editor
                 {
                     _computeNameInput.value = _defaultComputeName;
                     SetIpInputs(_defaultIpAddress);
-                    _computeState = ComputeStatus.NotRegistered;
+                    ComputeState = ComputeStatus.NotRegistered;
                 }
                 else
                 {
@@ -137,7 +137,7 @@ namespace AmazonGameLift.Editor
                     _stateManager.IpAddress = matchingCompute.IpAddress;
                     _stateManager.WebSocketUrl = matchingCompute.GameLiftServiceSdkEndpoint;
                     SetIpInputs(matchingCompute.IpAddress);
-                    _computeState = ComputeStatus.Registered;
+                    ComputeState = ComputeStatus.Registered;
                 }
             }
             else
@@ -150,9 +150,9 @@ namespace AmazonGameLift.Editor
 
         private void OnReplaceComputeButtonClicked()
         {
-            if (_computeState is ComputeStatus.Registered)
+            if (ComputeState is ComputeStatus.Registered)
             {
-                _computeState = ComputeStatus.Registering;
+                ComputeState = ComputeStatus.Registering;
             }
 
             UpdateGUI();
@@ -160,9 +160,9 @@ namespace AmazonGameLift.Editor
 
         private void OnCancelReplaceButtonClicked()
         {
-            if (_computeState is ComputeStatus.Registering)
+            if (ComputeState is ComputeStatus.Registering)
             {
-                _computeState = ComputeStatus.Registered;
+                ComputeState = ComputeStatus.Registered;
             }
 
             UpdateGUI();
@@ -196,7 +196,7 @@ namespace AmazonGameLift.Editor
 
         private List<VisualElement> GetVisibleItemsByState()
         {
-            return _computeState switch
+            return ComputeState switch
             {
                 ComputeStatus.Disabled => new List<VisualElement>(),
                 ComputeStatus.NotRegistered => new List<VisualElement>() { _registerButton, },


### PR DESCRIPTION
Foldout will now hide until it is ready to be pressed after "is bootstrapped, the fleet is selected, and the compute is registered"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
