### PR TITLE
Added a compute name clear on creating a new fleet;

### DIFF
--- a/Editor/Window/ConnectToFleetInput.cs
+++ b/Editor/Window/ConnectToFleetInput.cs
@@ -75,6 +75,7 @@ namespace AmazonGameLift.Editor
                     _stateManager.AnywhereFleetName = createFleetResponse.FleetName;
                     _stateManager.AnywhereFleetId = createFleetResponse.FleetId;
                     _stateManager.AnywhereFleetLocation = customLocationResponse.Location;
+                    _stateManager.ComputeName = "";
 
                     await UpdateFleetMenu();
                     _fleetState = FleetStatus.Selected;


### PR DESCRIPTION
Because when we create a new fleet the compute shouldn't be ever filled out, I have added it to remove the compute name, so that when we check if launch server should be enabled it will not be anymore.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
