### PR TITLE
Fixed boxes being closed after opening in bootstrap

### DIFF
--- a/Editor/Window/AwsUserProfilesPage.cs
+++ b/Editor/Window/AwsUserProfilesPage.cs
@@ -215,8 +215,8 @@ namespace AmazonGameLift.Editor
             var bucketResponse = _bootstrapSettings.CreateBucket(bucketName);
             if (bucketResponse.Success || bucketResponse.ErrorCode == BucketErrorCode.BucketNameAlreadyExists)
             {
-                _statusBox.Show(StatusBox.StatusBoxType.Success, Strings.UserProfilePageStatusBoxSuccessText);
                 _stateManager.SetBucketBootstrap(bucketName);
+                _statusBox.Show(StatusBox.StatusBoxType.Success, Strings.UserProfilePageStatusBoxSuccessText);
             }
             else
             {


### PR DESCRIPTION
`_stateManager.SetBucketBootstrap(bucketName);` would close all status boxes as it updated the user profile. So I have swapped them so it will show after it has changed everything.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
