### PR TITLE
Attempted fix for using stale game sessions

### DIFF
--- a/Samples~/SampleGame/Assets/Scripts/Server/GameLiftServer.cs
+++ b/Samples~/SampleGame/Assets/Scripts/Server/GameLiftServer.cs
@@ -79,7 +79,7 @@ public class GameLiftServer
             computeName = _settings.GetSetting(ServerSettingsKeys.ComputeName).Value;
 #endif
             var serverParams =
-                new ServerParameters(websocketUrl, $"{Application.productName}-{Guid.NewGuid()}", computeName, fleetID,
+                new ServerParameters(websocketUrl, $"{Guid.NewGuid()}", computeName, fleetID,
                     authToken);
 
             GenericOutcome initOutcome = GameLiftServerAPI.InitSDK(serverParams);
@@ -254,6 +254,10 @@ public class GameLiftServer
         catch (Exception e)
         {
             _logger.Write(":( PROCESSENDING FAILED. ProcessEnding() exception " + Environment.NewLine + e.Message);
+        }
+        finally
+        {
+            GameLiftServerAPI.Destroy();
         }
     }
 

--- a/Samples~/SampleGame/Assets/Scripts/Server/GameLiftServer.cs
+++ b/Samples~/SampleGame/Assets/Scripts/Server/GameLiftServer.cs
@@ -21,9 +21,10 @@ using AmazonGameLift.Editor;
 
 public class GameLiftServer
 {
+    public static readonly string ServerConfigFilePath = "GameLiftServerRuntimeSettings.yaml";
+    private static readonly string ProcessIDPrefix = "Amazon-GameLift-SampleGame";
     private readonly GameLift _gl;
     private readonly Logger _logger;
-    public static readonly string ServerConfigFilePath = "GameLiftServerRuntimeSettings.yaml";
     private readonly Settings<ServerSettingsKeys> _settings;
 #if UNITY_EDITOR
     private readonly ICredentialsStore _credentialsStore;
@@ -79,8 +80,7 @@ public class GameLiftServer
             computeName = _settings.GetSetting(ServerSettingsKeys.ComputeName).Value;
 #endif
             var serverParams =
-                new ServerParameters(websocketUrl, $"{Guid.NewGuid()}", computeName, fleetID,
-                    authToken);
+                new ServerParameters(websocketUrl, $"{ProcessIDPrefix}-{Guid.NewGuid()}", computeName, fleetID, authToken);
 
             GenericOutcome initOutcome = GameLiftServerAPI.InitSDK(serverParams);
 


### PR DESCRIPTION
Two changes for attempting to fix connectinng to stale game sessions

- Ensure process id is correct + unique, using product name could create invalid values
- Call GameLiftServerAPI.Destroy after ProcessEnding


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
