### PR TITLE
Defer unity defaults

### DIFF
--- a/Editor/Resources/EditorWindow/Components/ConnectToFleetInput.uxml
+++ b/Editor/Resources/EditorWindow/Components/ConnectToFleetInput.uxml
@@ -9,7 +9,7 @@
             <ui:VisualElement name="AnywherePageCreateFleetName" class="form-row">
                 <ui:Label name="AnywherePageCreateFleetNameLabel" class="form-row__label" text="Fleet Name"/>
                 <ui:VisualElement class="form-row__input">
-                    <ui:TextField name="AnywherePageCreateFleetNameInput" class="text-input" value="GameName-AnywhereFleet"/>
+                    <ui:TextField name="AnywherePageCreateFleetNameInput" class="text-input separator__single--tiny separator--vertical" value="GameName-AnywhereFleet"/>
                     <ui:Label name="AnywherePageCreateFleetNameHint" class="input-hint" text="Fleet Name must have 1–1024 characters. Valid characters are A-Z, a-z, 0-9, _ and - (hyphen)"/>
                 </ui:VisualElement>
             </ui:VisualElement>

--- a/Editor/Resources/EditorWindow/Components/DeploymentParameters.uxml
+++ b/Editor/Resources/EditorWindow/Components/DeploymentParameters.uxml
@@ -1,7 +1,7 @@
 ﻿<!-- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-<ui:UXML xmlns:ui="UnityEngine.UIElements">
+<ui:UXML xmlns:ui="UnityEngine.UIElements" class="separator separator--vertical">
     <Style src="../common.uss"/>
     <ui:VisualElement class="form-row">
         <ui:Label name="ManagedEC2ParametersGameNameLabel" class="form-row__label" text="Game Name"/>

--- a/Editor/Resources/EditorWindow/Pages/UserProfileCreation.uxml
+++ b/Editor/Resources/EditorWindow/Pages/UserProfileCreation.uxml
@@ -5,24 +5,20 @@
     <Style src="../common.uss"/>
     <ui:VisualElement class="separator separator--vertical separator--large">
         <ui:Label name="UserProfilePageAccountNewProfileTitle" class="page__subtitle" text="AWS Account Details"/>
-        <ui:VisualElement>
+        <ui:VisualElement class="separator separator--vertical">
             <ui:VisualElement name="UserProfilePageAccountNewProfileName" class="form-row">
                 <ui:Label name="UserProfilePageAccountNewProfileName" class="form-row__label" text="AWS Account Profile"/>
                 <ui:TextField name="UserProfilePageAccountNewProfileNameInput" class="form-row__input text-input"/>
             </ui:VisualElement>
             <ui:VisualElement name="UserProfilePageAccountNewProfileAccessKey" class="form-row">
                 <ui:Label name="UserProfilePageAccountNewProfileAccessKeyInput" text="AWS Access Key" class="form-row__label"/>
-                <ui:VisualElement class="separator separator--horizontal form-row__input">
-                    <ui:TextField name="UserProfilePageAccountNewProfileAccessKeyInput" class="text-input" password="true"/>
-                    <ui:Button name="UserProfilePageAccountNewProfileAccessKeyToggleReveal" class="button button--narrow form-row__reveal-button" text="Show"/>
-                </ui:VisualElement>
+                <ui:TextField name="UserProfilePageAccountNewProfileAccessKeyInput" class="text-input form-row__input separator__single--small separator--horizontal" password="true"/>
+                <ui:Button name="UserProfilePageAccountNewProfileAccessKeyToggleReveal" class="button button--narrow form-row__reveal-button" text="Show"/>
             </ui:VisualElement>
             <ui:VisualElement name="UserProfilePageAccountNewProfileSecretKey" class="form-row">
                 <ui:Label name="UserProfilePageAccountNewProfileSecretKeyLabel" class="form-row__label" text="AWS Secret Key"/>
-                <ui:VisualElement class="separator separator--horizontal form-row__input">
-                    <ui:TextField name="UserProfilePageAccountNewProfileSecretKeyInput" class="text-input" password="true"/>
-                    <ui:Button name="UserProfilePageAccountNewProfileSecretKeyToggleReveal" class="button button--narrow form-row__reveal-button" text="Show"/>
-                </ui:VisualElement>
+                <ui:TextField name="UserProfilePageAccountNewProfileSecretKeyInput" class="text-input form-row__input separator__single--small separator--horizontal" password="true"/>
+                <ui:Button name="UserProfilePageAccountNewProfileSecretKeyToggleReveal" class="button button--narrow form-row__reveal-button" text="Show"/>
             </ui:VisualElement>
             <ui:VisualElement name="UserProfilePageAccountNewProfileRegion" class="form-row">
                 <ui:Label name="UserProfilePageAccountNewProfileRegionLabel" class="form-row__label" text="AWS Region"/>

--- a/Editor/Resources/EditorWindow/common.uss
+++ b/Editor/Resources/EditorWindow/common.uss
@@ -94,19 +94,20 @@ Image#FolderIcon {
 }
 
 .button {
-    border-radius: 4px;
-    border-width: var(--border-size-medium);
-    border-color: var(--color-button-border);
-    padding: var(--spacing-tiny) var(--spacing-large) var(--spacing-tiny) var(--spacing-large);
+    padding: var(--spacing-tiny) var(--spacing-large);
     margin: 0;
-    background-color: var(--color-button-default);
     font-size: var(--font-size-large);
     align-self: flex-start;
     flex-direction: row;
 }
 
-.button--primary {
+.button--primary,
+.button--primary.unity-disabled:hover {
     background-color: var(--color-button-primary);
+}
+
+.button--primary:hover {
+    background-color: var(--color-button-hover);
 }
 
 .button--secondary {
@@ -124,10 +125,6 @@ Image#FolderIcon {
 
 .button--full-width {
     align-self: stretch;
-}
-
-.button:hover {
-    background-color: var(--color-button-hover);
 }
 
 .divider {
@@ -211,6 +208,14 @@ Image#FolderIcon {
 .separator.separator--horizontal.separator--large > .separator.separator--horizontal.separator--large {
     /* large (parent) - large (child) */
     margin-right: 0;
+}
+
+.separator__single--small.separator--horizontal {
+    margin-right: var(--spacing-small);
+}
+
+.separator__single--tiny.separator--vertical {
+    margin-bottom: var(--spacing-tiny);
 }
 
 .external-link {
@@ -320,8 +325,6 @@ Image#ExternalLinkIcon {
 .form-row__radio-button .unity-radio-button__checkmark-background {
     width: var(--radio-button-outer);
     height: var(--radio-button-outer);
-    border-width: var(--border-size-thin);
-    border-color: var(--color-text-input-border);
     border-radius: 100%;
     padding: 0;
     margin-top: var(--spacing-tiny);
@@ -353,14 +356,14 @@ Image#ExternalLinkIcon {
 }
 
 .text-input {
-    margin: 0 0 8px 0;
-    padding: 4px 8px 4px 8px;
-    border-width: var(--border-size-medium);
-    border-radius: 4px;
-    border-color: var(--color-text-input-border);
-    background-color: var(--color-text-input-background);
+    margin: 0;
     font-size: var(--font-size-large);
     flex: 1 1 auto;
+}
+
+.text-input > .unity-text-field__input {
+    margin: 0;
+    padding: 4px 8px;
 }
 
 .text-input--fitted {
@@ -375,23 +378,8 @@ Image#ExternalLinkIcon {
     -unity-text-align: middle-center;
 }
 
-.text-input:hover {
-    border-color: var(--color-button-hover);
-}
-
-.text-input:focus {
-    border-color: var(--color-button-primary);
-}
-
 .text-input--error {
     border-color: var(--color-font-error);
-}
-
-.text-input > .unity-text-field__input {
-    margin: 0;
-    padding: 0;
-    border-width: 0;
-    background-color: rgba(0, 0, 0, 0);
 }
 
 .input-hint {
@@ -400,19 +388,13 @@ Image#ExternalLinkIcon {
 
 .dropdown {
     margin: 0;
-    padding: 4px 8px 4px 8px;
-    border-width: var(--border-size-medium);
-    border-radius: 4px;
-    border-color: var(--color-button-border);
-    background-color: var(--color-button-default);
     align-self: stretch;
     font-size: var(--font-size-large);
 }
 
 .dropdown > .unity-popup-field__input {
-    padding: 0;
-    border-width: 0;
-    background-color: rgba(0, 0, 0, 0);
+    margin: 0;
+    padding: 4px 8px;
 }
 
 .card {
@@ -431,7 +413,7 @@ Image#ExternalLinkIcon {
 
 .card--small .card__text {
     font-size: var(--font-size-small);
-    margin: 0 8px 0 8px;
+    margin: 0 8px;
 }
 
 .card--large {


### PR DESCRIPTION
Removing a large chunk of custom CSS to defer to Unity's default styling for the buttons, text fields, and dropdowns.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

![Screenshot 2023-11-10 at 4 18 31 PM](https://github.com/aws/amazon-gamelift-plugin-unity/assets/89040953/4bf42afd-23c4-43a4-9d43-9b90da7ae51b)
![Screenshot 2023-11-10 at 4 18 39 PM](https://github.com/aws/amazon-gamelift-plugin-unity/assets/89040953/a5f8557c-3b61-4d5b-8f5f-d3d19424dcf5)
