### PR TITLE
Clean styling tweaks

### DIFF
--- a/Editor/Resources/EditorWindow/Components/DeploymentParameters.uxml
+++ b/Editor/Resources/EditorWindow/Components/DeploymentParameters.uxml
@@ -25,16 +25,16 @@
     </ui:VisualElement>
     <ui:VisualElement class="form-row">
         <ui:Label name="ManagedEC2ParametersGameServerFolderLabel" class="form-row__label" text="Game Server Folder"/>
-        <ui:TextField name="ManagedEC2ParametersGameServerFolderInput" class="form-row__input text-input" value="..."/>
-        <ui:Button name="ManagedEC2ParametersGameServerFolderButton">
-            <ui:Image name="FolderIcon" class="icon" />
+        <ui:TextField name="ManagedEC2ParametersGameServerFolderInput" class="form-row__input text-input separator__single--tiny separator--horizontal" value="..."/>
+        <ui:Button name="ManagedEC2ParametersGameServerFolderButton" class="button button--icon button--full-height">
+            <ui:Image name="FolderIcon" class="icon--fill" />
         </ui:Button>
     </ui:VisualElement>
     <ui:VisualElement class="form-row">
         <ui:Label name="ManagedEC2ParametersGameServerFileLabel" class="form-row__label" text="Game Server file (.exe)"/>
-        <ui:TextField name="ManagedEC2ParametersGameServerFileInput" class="form-row__input text-input" value="..."/>
-        <ui:Button name="ManagedEC2ParametersGameServerFileButton">
-            <ui:Image name="FolderIcon" class="icon" />
+        <ui:TextField name="ManagedEC2ParametersGameServerFileInput" class="form-row__input text-input separator__single--tiny separator--horizontal" value="..."/>
+        <ui:Button name="ManagedEC2ParametersGameServerFileButton" class="button button--icon button--full-height">
+            <ui:Image name="FolderIcon" class="icon--fill" />
         </ui:Button>
     </ui:VisualElement>
 </ui:UXML>

--- a/Editor/Resources/EditorWindow/Components/ProfileSelector.uxml
+++ b/Editor/Resources/EditorWindow/Components/ProfileSelector.uxml
@@ -1,7 +1,7 @@
 ﻿<!-- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-<ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:gl="AmazonGameLift.Editor">
+<ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:gl="AmazonGameLift.Editor" class="separator separator--vertical">
     <ui:Style src="../common.uss"/>
     <ui:VisualElement class="form-row">
         <ui:Label name="DropdownLabel" class="form-row__label"/>

--- a/Editor/Resources/EditorWindow/GameLiftPlugin.uss
+++ b/Editor/Resources/EditorWindow/GameLiftPlugin.uss
@@ -40,7 +40,7 @@
 }
 
 .tab__button:hover {
-    background-color: var(--color-button-hover);
+    background-color: var(--color-button-default-hover);
 }
 
 .tab__button--selected {

--- a/Editor/Resources/EditorWindow/Pages/GameLiftPluginBucketPopup.uss
+++ b/Editor/Resources/EditorWindow/Pages/GameLiftPluginBucketPopup.uss
@@ -7,6 +7,7 @@
     padding: var(--spacing-large);
     border-width: var(--border-size-medium);
     border-color: var(--color-border-highlight);
+    height: 100%;
 }
 
 .popup__heading {

--- a/Editor/Resources/EditorWindow/common.uss
+++ b/Editor/Resources/EditorWindow/common.uss
@@ -310,6 +310,7 @@ Image#ExternalLinkIcon {
 
 .form-row {
     flex-direction: row;
+    -unity-text-align: middle-left;
 }
 
 .form-row__label {
@@ -317,7 +318,6 @@ Image#ExternalLinkIcon {
     height: var(--form-row-height);
     color: var(--color-input-label);
     font-size: var(--font-size-large);
-    -unity-text-align: middle-left;
 }
 
 .form-row__input {
@@ -331,7 +331,6 @@ Image#ExternalLinkIcon {
 
 .form-row__text-display {
     flex: 1 1 auto;
-    padding: 2px;
 }
 
 .form-row__input--no-label {

--- a/Editor/Resources/EditorWindow/common.uss
+++ b/Editor/Resources/EditorWindow/common.uss
@@ -7,7 +7,8 @@
     --color-button-primary: #2C5D87;
     --color-button-secondary: #e4e4e4;
     --color-button-default: #585858;
-    --color-button-hover: #386082;
+    --color-button-primary-hover: #386082;
+    --color-button-default-hover: #666666;
     --color-button-border: #242424;
     --color-border-accent: #4c4c4c;
     --color-border-highlight: #9a9a9a;
@@ -23,6 +24,7 @@
     --color-text-input-border: #0d0d0d;
     --color-card-border: #0d0d0d;
     --color-card-background: #2a2a2a;
+    --color-clear: rgba(0,0,0,0);
 
     --font-size-hint: 12px;
     --font-size-small: 14px;
@@ -89,6 +91,12 @@ Image.icon--tiny {
     flex: 0 0 auto;
 }
 
+Image.icon--fill {
+    height: 100%;
+    width: 100%;
+    flex: 0 0 auto;
+}
+
 Image#FolderIcon {
     --unity-image: resource("Images/Icons/Folder");
 }
@@ -103,13 +111,25 @@ Image#FolderIcon {
     flex-direction: row;
 }
 
+.button--icon {
+    padding: 0;
+    align-items: center;
+    justify-content: center;
+    background-color: var(--color-clear);
+    border-color: var(--color-clear);
+}
+
+.button--icon:hover {
+    background-color: var(--color-button-default-hover);
+}
+
 .button--primary,
 .button--primary.unity-disabled:hover {
     background-color: var(--color-button-primary);
 }
 
 .button--primary:hover {
-    background-color: var(--color-button-hover);
+    background-color: var(--color-button-primary-hover);
 }
 
 .button--secondary {
@@ -127,6 +147,10 @@ Image#FolderIcon {
 
 .button--full-width {
     width: 100%;
+}
+
+.button--full-height {
+    height: 100%;
 }
 
 .divider {
@@ -214,6 +238,10 @@ Image#FolderIcon {
 
 .separator__single--small.separator--horizontal {
     margin-right: var(--spacing-small);
+}
+
+.separator__single--tiny.separator--horizontal {
+    margin-right: var(--spacing-tiny);
 }
 
 .separator__single--tiny.separator--vertical {

--- a/Editor/Resources/EditorWindow/common.uss
+++ b/Editor/Resources/EditorWindow/common.uss
@@ -98,6 +98,8 @@ Image#FolderIcon {
     margin: 0;
     font-size: var(--font-size-large);
     align-self: flex-start;
+    align-items: center;
+    justify-content: center;
     flex-direction: row;
 }
 
@@ -124,7 +126,7 @@ Image#FolderIcon {
 }
 
 .button--full-width {
-    align-self: stretch;
+    width: 100%;
 }
 
 .divider {

--- a/Editor/Resources/EditorWindow/common.uss
+++ b/Editor/Resources/EditorWindow/common.uss
@@ -7,7 +7,7 @@
     --color-button-primary: #2C5D87;
     --color-button-secondary: #e4e4e4;
     --color-button-default: #585858;
-    --color-button-primary-hover: #386082;
+    --color-button-primary-hover: #336C9D;
     --color-button-default-hover: #666666;
     --color-button-border: #242424;
     --color-border-accent: #4c4c4c;

--- a/Editor/Window/ManagedEC2Page.cs
+++ b/Editor/Window/ManagedEC2Page.cs
@@ -161,8 +161,6 @@ namespace AmazonGameLift.Editor
                 _deployButton.RemoveFromClassList(_primaryButtonClassName);
             }
 
-            _redeployButton.SetEnabled(_deploymentSettings.CurrentStackInfo.StackStatus != null &&
-                                       _deploymentSettings.CanDeploy);
             _deleteButton.SetEnabled(_deploymentSettings.CurrentStackInfo.StackStatus != null &&
                                      _deploymentSettings.IsCurrentStackModifiable);
 


### PR DESCRIPTION
Fixed a bug with removing the redeploy button from the managed ec2 UI that caused a NullPointerException.

Fixing various styling bugs:
* Popup border didn't fill the whole popup
* Primary button hover color didn't have much contrast compared to the default unity button
* Profile selector spacing was small compared to mocks
* The text displays in form UI didn't line up vertically with their labels
* Folder buttons in the Managed EC2 form UI did not match the mocks (too large and look like normal buttons)
* Landing page buttons did not fill their container

### Popup border didn't fill the whole space before

Before
![popup_border_w_bottom_trail](https://github.com/aws/amazon-gamelift-plugin-unity/assets/89040953/b5bf97fc-8d35-4b0c-88c3-9cd2ee8bd7ca)

After
![popup_border_fills_space](https://github.com/aws/amazon-gamelift-plugin-unity/assets/89040953/d01720cf-6d16-46eb-ba93-b48583fc978a)

### Primary button hover contrast is higher (~16% brightness increase which was measured based on default button hover contrast)
![primary_button_no_hover](https://github.com/aws/amazon-gamelift-plugin-unity/assets/89040953/be8d3a05-a127-4720-8181-1caa8eb95916)
![primary_button_w_hover](https://github.com/aws/amazon-gamelift-plugin-unity/assets/89040953/fb523b31-e2b4-4ede-9a70-df4183f26969)

### Profile selector spacing did not match the mocks + text items in the forms previously didn't line up vertically with their labels (this is fixed for the whole UI)

Before
![profile_before_spacing](https://github.com/aws/amazon-gamelift-plugin-unity/assets/89040953/2c6442f6-5979-4b0f-95c3-c376dbc4e1d9)

After
![profile_updated_spacing](https://github.com/aws/amazon-gamelift-plugin-unity/assets/89040953/04aac793-e76c-4dca-9134-cbe6607c6a8d)

### Folder buttons now match the mocks - no button visual until hovered over, and the sizing matches the input field

_Top button shows normal state, bottom button shows hovered state_
![updated_folder_buttons](https://github.com/aws/amazon-gamelift-plugin-unity/assets/89040953/8945ad59-cf8e-45d6-8349-f605256539e6)

### Landing page buttons now fill their container

![updated_landing_buttons](https://github.com/aws/amazon-gamelift-plugin-unity/assets/89040953/1bcd286e-5e2c-4562-825e-c4f640916790)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.