### PR TITLE
Clean up ServerSDK version and NPE

### DIFF
--- a/Editor/Resources/CloudFormation/scenario1_single_fleet/cloudformation.yml
+++ b/Editor/Resources/CloudFormation/scenario1_single_fleet/cloudformation.yml
@@ -365,7 +365,7 @@ Resources:
         Key: !Ref BuildS3KeyParameter
         RoleArn: !GetAtt BuildAccessRole.Arn
       Version: !Ref BuildVersionParameter
-      ServerSdkVersion: 5.1.1
+      ServerSdkVersion: 5.1.0
 
   FleetResource:
     Type: "AWS::GameLift::Fleet"

--- a/Editor/Resources/CloudFormation/scenario2_spot_fleets/cloudformation.yml
+++ b/Editor/Resources/CloudFormation/scenario2_spot_fleets/cloudformation.yml
@@ -525,7 +525,7 @@ Resources:
         Key: !Ref BuildS3KeyParameter
         RoleArn: !GetAtt BuildAccessRole.Arn
       Version: !Ref BuildVersionParameter
-      ServerSdkVersion: 5.1.1
+      ServerSdkVersion: 5.1.0
 
   GameRequestLambdaFunction:
     Type: "AWS::Lambda::Function"

--- a/Editor/Resources/CloudFormation/scenario3_flexmatch/cloudformation.yml
+++ b/Editor/Resources/CloudFormation/scenario3_flexmatch/cloudformation.yml
@@ -570,7 +570,7 @@ Resources:
         Key: !Ref BuildS3KeyParameter
         RoleArn: !GetAtt BuildAccessRole.Arn
       Version: !Ref BuildVersionParameter
-      ServerSdkVersion: 5.1.1
+      ServerSdkVersion: 5.1.0
 
   FlexMatchStatusPollerLambdaPermission:
     Type: "AWS::Lambda::Permission"

--- a/Editor/Window/AnywherePage.cs
+++ b/Editor/Window/AnywherePage.cs
@@ -83,7 +83,7 @@ namespace AmazonGameLift.Editor
 
             ComputeStatus computeStatus = _registerComputeInput.getComputeStatus();
             bool isComputeRegistered = computeStatus is ComputeStatus.Registered;
-            bool isClientConfigured = _gameLiftClientSettings.IsGameLiftAnywhere;
+            bool isClientConfigured = _gameLiftClientSettings && _gameLiftClientSettings.IsGameLiftAnywhere;
             bool isConfigureClientEnabled = isComputeRegistered && !isClientConfigured;
             
             _configureClientButton.SetEnabled(isConfigureClientEnabled);

--- a/THIRD_PARTY_LICENSES.TXT.meta
+++ b/THIRD_PARTY_LICENSES.TXT.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 91a970bef33737b479e0a4c87844187b
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
* Server sdk version was incorrectly 5.1.1 (doesn't exist for the lightweight GameLift Server sdk for Unity)
* Fix NPE with GameLiftClientSettings
* Add missing meta file

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
