### PR TITLE
Revert serialized field name change that broke prefabs

### DIFF
--- a/Samples~/SampleGame/Assets/Scripts/GameLift.cs
+++ b/Samples~/SampleGame/Assets/Scripts/GameLift.cs
@@ -27,7 +27,7 @@ public class GameLift : MonoBehaviour
     public static readonly string ClientConfigFilePath = "GameLiftAnywhereClientSettings.yaml";
 
     [SerializeField]
-    private GameLiftClientSettings _gameLiftClientSettings;
+    private GameLiftClientSettings _gameLiftSettings;
 
     private readonly Logger _logger = Logger.SharedInstance;
 #if UNITY_SERVER
@@ -79,7 +79,7 @@ public class GameLift : MonoBehaviour
         _server = new GameLiftServer(this, _logger);
 #else
         _logger.Write(":) I AM CLIENT");
-        var config = _gameLiftClientSettings.GetConfiguration();
+        var config = _gameLiftSettings.GetConfiguration();
         if (config.IsGameLiftAnywhere)
         {
 #if UNITY_EDITOR


### PR DESCRIPTION
Because the serialized field name was changed, the prefab asset no longer loads in the client settings asset. The key-value pair is still stored in the prefab asset however, so reverting the name change should resolve the prefabs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
