### PR TITLE
Support any client setting asset in UI with error messaging and periodic loading

### DIFF
--- a/Editor/CoreAPI/ErrorCode.cs
+++ b/Editor/CoreAPI/ErrorCode.cs
@@ -21,5 +21,7 @@ namespace AmazonGameLift.Editor
         public static readonly string DeregisterComputeFailed = "DeregisterComputeFailed";
         public static readonly string InvalidComputeName = "InvalidComputeName";
         public static readonly string InvalidIpAddress = "InvalidIpAddress";
+        public static readonly string GameLiftClientSettingsNotFoundText = "GameLiftClientSettingsNotFoundText";
+        public static readonly string GameLiftClientSettingsMoreThanOneFoundTemplate = "GameLiftClientSettingsMoreThanOneFoundTemplate";
     }
 }

--- a/Editor/Resources/EditorWindow/Pages/AnywherePage.uxml
+++ b/Editor/Resources/EditorWindow/Pages/AnywherePage.uxml
@@ -28,6 +28,7 @@
         <ui:Foldout name="AnywherePageConnectFleetTitle" class="foldout" text="Connect to Anywhere Fleet"/>
         <ui:Foldout name="AnywherePageComputeTitle" class="foldout" text="Register Compute"/>
         <ui:Foldout name="AnywherePageLaunchTitle" class="foldout separator separator--vertical" text="Launch foldout">
+            <gl:StatusBox name="AnywherePageLaunchStatusBox"/>
             <ui:VisualElement class="form-row">
                 <ui:Label name="AnywherePageConfigureClientLabel" class="form-row__label" text="Configure Client"/>
                 <ui:VisualElement class="form-row__input">

--- a/Editor/Resources/EditorWindow/Pages/ManagedEC2Page.uxml
+++ b/Editor/Resources/EditorWindow/Pages/ManagedEC2Page.uxml
@@ -46,6 +46,7 @@
             </ui:VisualElement>
         </ui:Foldout>
         <ui:Foldout name="ManagedEC2LaunchClientTitle" class="foldout separator separator--vertical" text="Launch Client">
+            <gl:StatusBox name="ManagedEC2LaunchStatusBox"/>
             <ui:VisualElement class="form-row">
                 <ui:Label name="ManagedEC2ConfigureClientLabel" class="form-row__label" text="Configure Client"/>
                 <ui:Button name="ManagedEC2ConfigureClientButton" class="button button--primary" text="Configure Client"/>

--- a/Editor/TextProvider.cs
+++ b/Editor/TextProvider.cs
@@ -51,6 +51,8 @@ namespace AmazonGameLift.Editor
             { ErrorCode.StackStatusInvalid, "Something went wrong  with the deployment that requires attention. Go to the AWS CloudFormation console and view details for the failing stack. After resolving the problem, delete and re-create the deployment."},
             { ErrorCode.ValueInvalid, "There was a problem with the value."},
             { ErrorCode.WritingFileFailed, "There was a problem writing to the file."},
+            { ErrorCode.GameLiftClientSettingsNotFoundText, "No GameLiftClientSettings asset found. Please import the sample game or create one custom."},
+            { ErrorCode.GameLiftClientSettingsMoreThanOneFoundTemplate, "More than one GameLiftClientSettings asset was found. Using asset found at \"{0}\"."},
         };
 
         private readonly Dictionary<string, string> _textsByKey = new Dictionary<string, string>

--- a/Editor/Window/Components/GameLiftClientSettingsLoader.cs
+++ b/Editor/Window/Components/GameLiftClientSettingsLoader.cs
@@ -1,0 +1,46 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using UnityEngine;
+using UnityEngine.UIElements;
+using UnityEditor;
+using AmazonGameLift.Runtime;
+
+namespace AmazonGameLift.Editor
+{
+    public class GameLiftClientSettingsLoader
+    {
+        private StatusBox _statusBox;
+        private TextProvider _textProvider;
+
+        public GameLiftClientSettingsLoader(StatusBox statusBox)
+        {
+            this._statusBox = statusBox;
+            this._textProvider = TextProviderFactory.Create();
+        }
+
+        public GameLiftClientSettings LoadAsset()
+        {
+            string[] guids = AssetDatabase.FindAssets("t:GameLiftClientSettings");
+
+            _statusBox.Close();
+
+            if (guids.Length <= 0 || string.IsNullOrWhiteSpace(guids[0]))
+            {
+                _statusBox.Show(StatusBox.StatusBoxType.Error, _textProvider.GetError(ErrorCode.GameLiftClientSettingsNotFoundText));
+                return null;
+            }
+
+            string assetPath = AssetDatabase.GUIDToAssetPath(guids[0]);
+
+            if (guids.Length > 1)
+            {
+                _statusBox.Show(StatusBox.StatusBoxType.Warning,
+                    String.Format(_textProvider.GetError(ErrorCode.GameLiftClientSettingsMoreThanOneFoundTemplate), assetPath));
+            }
+
+            return AssetDatabase.LoadAssetAtPath<GameLiftClientSettings>(assetPath);
+        }
+    }
+}

--- a/Editor/Window/Components/GameLiftClientSettingsLoader.cs.meta
+++ b/Editor/Window/Components/GameLiftClientSettingsLoader.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 02171e714fbc71e4e968109e34910b8d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Added support to Anywhere and Managed EC2 tab to load in client setting assets from any path in the project instead of only the path that the sample plugin uses.

Additionally,
* If you don't have an asset, an error will appear and the apply/launch buttons will be disabled.
* If you have **more than one asset**, a warning will appear that will indicate which asset is being used.
* The UI periodically (every 2 seconds) reloads this asset and the UI so if you manually change the asset the UI will update the error message and launch/configure buttons accordingly. Examples:
  * If you delete your setting, the error will appear.
  * If you create a new setting when one already existed, the warning will appear.
  * If you edit your deployment settings in the inspector, the ManagedEC2 UI will re-enable the Configure Client button as the settings are out of sync.

Known issue,
* The Sample game still relies on the specific asset it comes with, so if the user deletes this asset, their sample will fail (the sample has references to this asset and will throw a NPE in this case)

![Screenshot 2023-11-15 at 12 54 06 PM](https://github.com/aws/amazon-gamelift-plugin-unity/assets/89040953/db481aad-dcda-4d66-98eb-04c1b65c2540)
![Screenshot 2023-11-15 at 12 54 15 PM](https://github.com/aws/amazon-gamelift-plugin-unity/assets/89040953/0c767fd0-e0da-4c59-83b1-df550ec355e2)
![Screenshot 2023-11-15 at 12 54 24 PM](https://github.com/aws/amazon-gamelift-plugin-unity/assets/89040953/891fcafb-11a2-474f-a358-91c53a2b75e4)
![Screenshot 2023-11-15 at 12 54 39 PM](https://github.com/aws/amazon-gamelift-plugin-unity/assets/89040953/9dff3a45-db80-450a-9460-ade1dbef34b7)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
