### PR TITLE
GLIFT-22897: fix anywhere fleet dropdown fleet name not show for mac

### DIFF
--- a/Editor/Window/ConnectToFleetInput.cs
+++ b/Editor/Window/ConnectToFleetInput.cs
@@ -113,9 +113,9 @@ namespace AmazonGameLift.Editor
 
         private async void OnSelectFleetDropdown(string fleetSelection)
         {
-            var items = fleetSelection.Split(" | ");
+            var items = fleetSelection.Split(" (");
             var fleetName = items[0];
-            var fleetId = items[1];
+            var fleetId = items[1].Remove(items[1].Length - 1, 1);
             var currentFleet =
                 _fleetAttributes.FirstOrDefault(fleet => fleet.Name == fleetName && fleet.FleetId == fleetId);
             if (currentFleet != null)
@@ -167,7 +167,7 @@ namespace AmazonGameLift.Editor
                 var textProvider = new TextProvider();
 
                 _fleetNameDropdownContainer.choices =
-                    _fleetAttributes.Select(fleet => $"{fleet.Name} | {fleet.FleetId}").ToList();
+                    _fleetAttributes.Select(fleet => $"{fleet.Name} ({fleet.FleetId})").ToList();
                 if (string.IsNullOrWhiteSpace(_stateManager.AnywhereFleetId))
                 {
                     _fleetNameDropdownContainer.SetValueWithoutNotify(
@@ -176,7 +176,7 @@ namespace AmazonGameLift.Editor
                 else
                 {
                     _fleetNameDropdownContainer.value =
-                        $"{_stateManager.AnywhereFleetName} | {_stateManager.AnywhereFleetId}";
+                        $"{_stateManager.AnywhereFleetName} ({_stateManager.AnywhereFleetId})";
                 }
 
                 _fleetIdText.text = _stateManager.AnywhereFleetId;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* When working through the "Host with Anywhere" flow with existing fleets, there is a dropdown selector to pick the fleet to use. On Windows, this dropdown includes the name of the fleet and the id in the following format: "<fleet-name> | <fleet-id>"; however, on Mac the dropdown only displays the fleet id. This change change the format to fleetname (fleetId) so that fleetname and fleetId show up for both windows and mac.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
